### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update \
-    && apt-get --no-install-recommends install -y apt-utils curl wget git tree ne software-properties-common apt-transport-https ca-certificates
+    && apt-get --no-install-recommends install -y apt-utils curl wget git tree ne software-properties-common apt-transport-https ca-certificates build-essential
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y curl wget git tree ne software-properties-common apt-transport-https ca-certificates
+RUN apt-get update \
+    && apt-get --no-install-recommends install -y apt-utils curl wget git tree ne software-properties-common apt-transport-https ca-certificates
 
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
@@ -9,7 +10,7 @@ RUN add-apt-repository -y ppa:ethereum/ethereum
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 
 # RUN apt-get update # done by node script above
-RUN apt-get install -y nodejs ruby haskell-stack golang-go google-cloud-sdk kubectl ethereum libdb-dev libleveldb-dev libsodium-dev zlib1g-dev libtinfo-dev
+RUN apt-get --no-install-recommends  install -y nodejs ruby haskell-stack golang-go google-cloud-sdk kubectl ethereum libdb-dev libleveldb-dev libsodium-dev zlib1g-dev libtinfo-dev
 RUN gem install colorize
 RUN npm install web3
 ENV PATH=/root/go/bin:$PATH


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is

1.  Slow  because "apt-utils" not installed

2. to avoid build to exits with error without having certificate

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>