### PR TITLE
Adding github actions and workflow.

### DIFF
--- a/.github/actions/qube-gen-k8s/Dockerfile
+++ b/.github/actions/qube-gen-k8s/Dockerfile
@@ -1,0 +1,7 @@
+FROM quorumengineering/qubernetes
+
+# we don't want to use the generators baked into the docker image,
+# as it is the generators that we need to test: copy the committed base directory
+# over the to the base docker image directory.
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/qube-gen-k8s/action.yaml
+++ b/.github/actions/qube-gen-k8s/action.yaml
@@ -1,0 +1,12 @@
+name: 'Quorum k8s resource generator'
+description: 'Qubernetes Docker image for generating K8s resources'
+inputs:
+  config-prefix:  # id of input which we can be passed to Docker.
+    description: 'config directory prefix used to generate the k8s resources.'
+    required: true
+    default: '7nodes'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.config-prefix }}

--- a/.github/actions/qube-gen-k8s/entrypoint.sh
+++ b/.github/actions/qube-gen-k8s/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -l
+
+CONFIG_PREFIX=$1
+echo "Running test for config prefix $CONFIG_PREFIX"
+# generate the K8s resrouces using the file in this commit/github workspace
+/github/workspace/testing/gen-configs.sh ${CONFIG_PREFIX}

--- a/.github/workflows/7nodes-test.yaml
+++ b/.github/workflows/7nodes-test.yaml
@@ -1,0 +1,42 @@
+# Workflow to test the generation of 7nodes examples against the most recently committed qubernetes files:
+#
+# 1. Generates the necessary K8s resource files for various quorum networks configurations:
+#    Privacy Manger (tessera and constellation) and  consensus (IBFT and Raft).
+# 2. Deploys each network to a running kubernetes service (kind) and tests deploying a contract (private and public).
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on all push events and on pull requests to the master branch
+# https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: [ master ]
+
+# This workflow has one job run sequentially which installs kind (K8s service), generates fresh 7nodes examples, and
+# deployes all 7nodes quorum networks to kinds testing public and private transaction on them.
+jobs:
+  # This workflow contains a single job called "test-7nodes"
+  test-7nodes:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out qubernetes under $GITHUB_WORKSPACE, so this job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+      - name: Install latest version of Kind
+        run: |
+          GO111MODULE=on go get sigs.k8s.io/kind
+      # https://help.github.com/en/actions/building-actions/creating-a-docker-container-action
+      - name: Generate k8s resources via qubernetes docker
+        uses: ./.github/actions/qube-gen-k8s
+        with:
+          config-prefix: 7nodes
+      # output files should now be in the working directory /home/runner/work/qubernetes/qubernetes
+      - name: Run 7nodes example on K8s (kind)
+        run: $GITHUB_WORKSPACE/testing/test-k8s-resources.sh 7nodes


### PR DESCRIPTION
Adding github actions and workflow to test the generation of the
7nodes examples, uses the public qubernetes docker image for
generating the resources and tests the generation of the k8s yaml
which is then run on a k8s service (kind).
Triggered  when a commit is pushed, or PR to master is opened.