### PR TITLE
Add ability to generate ingress resources.

### DIFF
--- a/examples/config/qubernetes-ingress.yaml
+++ b/examples/config/qubernetes-ingress.yaml
@@ -1,0 +1,58 @@
+#namespace:
+# name: quorum-test
+# number of nodes to deploy
+sep_deployment_files: true
+nodes:
+  number: 3
+service:
+  # NodePort | ClusterIP | LoadBalancer
+  type: NodePort
+  Ingress:
+    # OneToMany | OneToOne
+    Strategy: OneToMany
+    Host: "quorum.testnet.com"
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  # base quorum data dir as set inside each container.
+  Node_DataDir: /etc/quorum/qdata
+  # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
+  # Either full or relative paths on the machine generating the config
+  Key_Dir_Base: out/config
+  Permissioned_Nodes_File: out/config/permissioned-nodes.json
+  Genesis_File: out/config/genesis.json
+  # related to quorum containers
+  quorum:
+    Raft_Port: 50401
+    # container images at https://hub.docker.com/u/quorumengineering/
+    Quorum_Version: 2.2.5
+  # related to transaction manager containers
+  tm:
+    # container images at https://hub.docker.com/u/quorumengineering/
+    # (tessera|constellation)
+    Name: tessera
+    #Tm_Version: 0.9.2
+    Tm_Version: 0.10.0
+    Port: 9001
+    Tessera_Config_Dir: out/config
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP
+  # The data dir is persisted here
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 200Mi
+# generic geth related options
+geth:
+  Node_RPCPort: 8545
+  NodeP2P_ListenAddr: 30303
+  network:
+    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
+    id: 1101
+    # public (true|false) is it a public network?
+    public: false
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\"

--- a/qubernetes
+++ b/qubernetes
@@ -96,8 +96,16 @@ File.open("out/02-quorum-shared-config.yaml", "w") do |f|
 end
 
 # Create the service resources
-File.open("out/03-quorum-services.yaml", "w") do |f|
+File.open("out/03.0-quorum-services.yaml", "w") do |f|
   f.puts (ERB.new(File.read(@base_template_path + "/quorum-services.yaml.erb"), nil, "-").result)
+end
+
+
+# Create the Ingress resources if they are configured
+if @config["service"]["Ingress"]
+  File.open("out/03.1-quorum-ingress.yaml", "w") do |f|
+    f.puts (ERB.new(File.read(@base_template_path + "/quorum-ingress.yaml.erb"), nil, "-").result)
+  end
 end
 
 # make all keystore resrouce (configMap)

--- a/templates/k8s/quorum-ingress.yaml.erb
+++ b/templates/k8s/quorum-ingress.yaml.erb
@@ -1,0 +1,85 @@
+<%-
+def set_node_template_vars(values)
+    @Node_UserIdent = values["Node_UserIdent"]
+    return
+end
+
+@Service_Prefix        = (@Node_UserIdent.upcase).gsub("-", "_")
+@TM_Port               = @config["quorum"]["tm"]["Port"]
+@Node_RPCPort          = @config["geth"]["Node_RPCPort"]
+@NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
+# NodePort | ClusterIP | Loadbalancer
+@Service_Type          = @config["service"]["type"]
+
+if @Service_Type == "NodePort" and @config["service"]["Ingress"] then
+   @Ingress = true
+   # OneForAll
+   @IngressStrategy = @config["service"]["Ingress"]["Strategy"]
+   if @config["service"]["Ingress"]["Host"]  then
+     @Ingress_Host = @config["service"]["Ingress"]["Host"]
+   end
+end
+
+-%>
+
+<%# Strategy OneToOne - this will create one Ingress per node service in the cluster %>
+<%# in this strategy each node will get its own FQDN with the nodeId as the first part of the domain %>
+<%- if @Ingress and @IngressStrategy == "OneToOne" -%>
+<%- @nodes.each do |node| -%>
+<%= set_node_template_vars(node.values.first) -%>
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+    <%= @Namespace %>
+  name: <%= @Node_UserIdent %>
+spec:
+  rules:
+      <%- if @Ingress_Host -%>
+    - host:  <%= @Node_UserIdent %>.<%= @Ingress_Host %>
+      http:
+        paths:
+          - path: /rpc
+            backend:
+              serviceName: <%= @Node_UserIdent %>
+              servicePort: <%= @Node_RPCPort %>
+      <%- else -%>
+    - http:
+        paths:
+          - path: /rpc
+            backend:
+              serviceName: <%= @Node_UserIdent %>
+              servicePort: <%= @Node_RPCPort %>
+          <%- end -%> <%# End Host conditional %>
+     <% end -%> <%# end this node iteration %>
+<%- end -%> <%# End Ingress OneForEach (this node's ingress) %>
+
+
+
+<%# If an ingresses has been specified with strategy OneToMany, create a single Ingress for all the nodes in the cluster %>
+<% if @Ingress and @IngressStrategy == "OneToMany" %>
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+    <%= @Namespace %>
+  name: quorum-ingress
+spec:
+  rules:
+      <%- if @Ingress_Host -%>
+    - host: <%= @Ingress_Host %>
+      http:
+      <%- else -%>
+    - http:
+          <%- end -%> <%# end  Host conditional%>
+        paths:
+            <%- # create paths for each node -%>
+            <%- @nodes.each do |node| -%>
+            <%- set_node_template_vars(node.values.first) -%>
+          - path: /<%= @Node_UserIdent %>/rpc
+            backend:
+              serviceName: <%= @Node_UserIdent %>
+              servicePort: <%= @Node_RPCPort %>
+          <%- end -%> <%# end setting path for each node %>
+    <%- end %> <%# end  Ingress conditional%>

--- a/templates/k8s/quorum-services.yaml.erb
+++ b/templates/k8s/quorum-services.yaml.erb
@@ -1,20 +1,20 @@
-<%
+<%-
+
 def set_node_template_vars(values)
     @Node_UserIdent = values["Node_UserIdent"]
     return
 end
+
+@Service_Prefix        = (@Node_UserIdent.upcase).gsub("-", "_")
+@TM_Port               = @config["quorum"]["tm"]["Port"]
+@Node_RPCPort          = @config["geth"]["Node_RPCPort"]
+@NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
+# NodePort | ClusterIP | Loadbalancer
+@Service_Type          = @config["service"]["type"]
 -%>
 
 <%- @nodes.each do |node| -%>
-    <%= set_node_template_vars(node.values.first) -%>
-
-<%
-    @Service_Prefix        = (@Node_UserIdent.upcase).gsub("-", "_")
-    @TM_Port               = @config["quorum"]["tm"]["Port"]
-    @Node_RPCPort          = @config["geth"]["Node_RPCPort"]
-    @NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
-%>
-
+<%= set_node_template_vars(node.values.first) -%>
 ---
 apiVersion: v1
 kind: Service
@@ -30,7 +30,7 @@ spec:
     app: qubernetes
     tier: backend
     name: <%= @Node_UserIdent %>-deployment
-  # NodePort | ClusterIP
+  # NodePort | ClusterIP | Loadbalancer
   type: <%= @config["service"]["type"] %>
   ports:
     - name: tm-manager 
@@ -55,4 +55,5 @@ spec:
       protocol: TCP
       targetPort: <%= @Raft_Port %>
       port: <%= @Raft_Port %>
-<% end -%>
+
+<%- end %> <%# end node iteration %>


### PR DESCRIPTION
Add the ability to generate ingress resources, either
OneToOne where a k8s ingress resource is created for each
node (1:1), or OneToMany (1:N) where one ingress resource is created
for all quorum  nodes deployed in the cluster, and all nodes share a
common host name.

Currently only support one host FQDN per ingress.

Only exposing the geth rpc endpoint.

Not supporting tls at this time, however tls can be added with
self signed certificate (which would requires modification of the
geth client) or using a valid root CA.