### PR TITLE
Make the docker repo optionally configurable.

### DIFF
--- a/examples/config/qubernetes-custom-docker-repo.yaml
+++ b/examples/config/qubernetes-custom-docker-repo.yaml
@@ -1,0 +1,55 @@
+#namespace:
+#  name: quorum-test
+# number of nodes to deploy
+sep_deployment_files: true
+nodes:
+  number: 4
+service:
+  # NodePort | ClusterIP
+  type: NodePort
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  # base quorum data dir as set inside each container.
+  Node_DataDir: /etc/quorum/qdata
+  # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
+  # Either full or relative paths on the machine generating the config
+  Key_Dir_Base: out/config
+  Permissioned_Nodes_File: out/config/permissioned-nodes.json
+  Genesis_File: out/config/genesis.json
+  # related to quorum containers
+  quorum:
+    Raft_Port: 50401
+    Quorum_Version: 2.4.0
+    # the docker repo that hold your quorum container
+    Docker_Repo: %%YOUR_CUSTOM_DOCKER_REPO%%
+  # related to transaction manager containers
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+    # the docker repo that hold your quorum container
+    Docker_Repo: %%YOUR_CUSTOM_DOCKER_REPO%%
+    Port: 9001
+    Tessera_Config_Dir: out/config
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP
+  # The data dir is persisted here
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 5Gi
+# generic geth related options
+geth:
+  Node_RPCPort: 8545
+  NodeP2P_ListenAddr: 30303
+  network:
+    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
+    id: 1101
+    # public (true|false) is it a public network?
+    public: false
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\"

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -14,10 +14,21 @@ end
 
 @Node_DataDir          = @config["quorum"]["Node_DataDir"]
 @Quorum_Version        = @config["quorum"]["quorum"]["Quorum_Version"]
+# default quorumengineering/quorum
+if @config["quorum"]["quorum"]["Docker_Repo"]
+ @Quorum_Docker_Repo = @config["quorum"]["quorum"]["Docker_Repo"]
+else
+ @Quorum_Docker_Repo =  "quorumengineering"
+end
+# default quorumengineering/quorum
+if @config["quorum"]["tm"]["Docker_Repo"]
+ @Tm_Docker_Repo = @config["quorum"]["tm"]["Docker_Repo"]
+else
+ @Tm_Docker_Repo =  "quorumengineering"
+end
 @Tm_Version            = @config["quorum"]["tm"]["Tm_Version"]
 @Tm_Port               = @config["quorum"]["tm"]["Port"]
 @Tm_Name               = @config["quorum"]["tm"]["Name"]
-
 # Storage for data directories, default PVC.
 @Storage_Type          = "PVC"
 # if storage is set set up the appropriate storage variable (host or PVC)
@@ -63,7 +74,7 @@ spec:
     spec:
       initContainers:
       - name: quorum-genesis-init-container
-        image: quorumengineering/quorum:<%= @Quorum_Version %>
+        image: <%= @Quorum_Docker_Repo %>/quorum:<%= @Quorum_Version %>
         command: [ "sh" ]
         args:
         - "-cx"
@@ -93,7 +104,7 @@ spec:
       containers:
     <%- if @Tm_Name == "constellation"  -%>
       - name: constellation
-        image: quorumengineering/constellation:<%= @Tm_Version %>
+        image:  <%= @Tm_Docker_Repo %>/constellation:<%= @Tm_Version %>
         command: ["sh"]
         args:
         - "-cx"
@@ -111,7 +122,7 @@ spec:
            /usr/local/bin/constellation-node $args  2>&1 | tee -a $QUORUM_HOME/logs/tm.log; "
      <%- else -%>
       - name: tessera
-        image: quorumengineering/tessera:<%= @Tm_Version %>
+        image: <%= @Tm_Docker_Repo %>/tessera:<%= @Tm_Version %>
         command: ["sh"]
         args:
         - "-cx"
@@ -185,7 +196,7 @@ spec:
           subPath: tessera-config-9.0.json.tmpl
         <%- end -%>
       - name: quorum
-        image: quorumengineering/quorum:<%= @Quorum_Version %>
+        image: <%= @Quorum_Docker_Repo %>/quorum:<%= @Quorum_Version %>
         command: [ "sh" ]
         # TODO: have to generate sed files
         #       PERM_NODE_JSON=$(echo $PERM_NODE_TMPL | sed \"s/%QUORUM-NODE01_SERVICE_HOST%/$QUORUM_NODE01_SERVICE_HOST/g\" | sed \"s/%QUORUM-NODE02_SERVICE_HOST%/$QUORUM_NODE02_SERVICE_HOST/g\");
@@ -218,7 +229,7 @@ spec:
          <%- if @config["quorum"]["consensus"] == "raft" -%>
            args=\" --gcmode archive --raft  --raftport <%= @Raft_Port %> --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,raft \";
          <%- elsif @config["quorum"]["consensus"] == "istanbul" -%>
-           args=\" --gcmode archive --istanbul.blockperiod 3  --syncmode full --mine --minerthreads 1 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul \";
+           args=\" --gcmode archive --istanbul.blockperiod 3 --syncmode full --mine --minerthreads 1 --rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,istanbul \";
          <%- else -%>
            args=\"--rpcapi admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum \";
          <%- end -%>


### PR DESCRIPTION
Add an optional `Docker_Repo` yaml entry for each container (Transaction Manager, quorum),
to the minimal config. This allows the user to configure the docker repo that the containers should be pulled from, e.g. their dev containers, internal repos, etc. If not set, the containers will be pulled from the official quorum docker hub repo: https://hub.docker.com/u/quorumengineering/.