### PR TITLE
Add network policy generation capability.

### DIFF
--- a/examples/config/qubernetes-network-policy.yaml
+++ b/examples/config/qubernetes-network-policy.yaml
@@ -1,0 +1,58 @@
+#namespace:
+#  name: quorum-test
+# number of nodes to deploy
+sep_deployment_files: true
+nodes:
+  number: 4
+service:
+  # NodePort | ClusterIP
+  type: NodePort
+  Ingress:
+    # OneToMany | OneToOne
+    Strategy: OneToOne
+    Host: "quorum.testnet.com"
+  NetworkPolicy: true
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  # base quorum data dir as set inside each container.
+  Node_DataDir: /etc/quorum/qdata
+  # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
+  # Either full or relative paths on the machine generating the config
+  Key_Dir_Base: out/config
+  Permissioned_Nodes_File: out/config/permissioned-nodes.json
+  Genesis_File: out/config/genesis.json
+  # related to quorum containers
+  quorum:
+    Raft_Port: 50401
+    # container images at https://hub.docker.com/u/quorumengineering/
+    Quorum_Version: 2.4.0
+  # related to transaction manager containers
+  tm:
+    # container images at https://hub.docker.com/u/quorumengineering/
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+    Port: 9001
+    Tessera_Config_Dir: out/config
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP
+  # The data dir is persisted here
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 5Gi
+# generic geth related options
+geth:
+  Node_RPCPort: 8545
+  NodeP2P_ListenAddr: 30303
+  network:
+    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
+    id: 1101
+    # public (true|false) is it a public network?
+    public: false
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\"

--- a/qubernetes
+++ b/qubernetes
@@ -113,6 +113,13 @@ File.open("out/04-quorum-keyconfigs.yaml", "w") do |f|
   f.puts (ERB.new(File.read(@base_template_path + "/quorum-keystore.yaml.erb"), nil, "-").result)
 end
 
+# if a network policy was requested create one for the namespace (NetworkPolicy = true in yaml config)
+if @config["service"]["NetworkPolicy"]
+  File.open("out/05-quorum-network-policy.yaml", "w") do |f|
+    f.puts (ERB.new(File.read(@base_template_path + "/network-policy.yaml.erb"), nil, "-").result)
+  end
+end
+
 @Kubectl_Cmd="  $> kubectl apply -f out"
 if @sep_deployment_files
  `mkdir -p out/deployments`

--- a/templates/k8s/network-policy.yaml.erb
+++ b/templates/k8s/network-policy.yaml.erb
@@ -1,0 +1,62 @@
+<%
+  @TM_Port               = @config["quorum"]["tm"]["Port"]
+  @Node_RPCPort          = @config["geth"]["Node_RPCPort"]
+  @NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
+ %>
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  <%= @Namespace %>
+  name: quorum-internal-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: qubernetes
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: qubernetes
+      ports:
+        -  port: <%= @TM_Port %>
+        -  port: 9080
+        -  port: <%= @Raft_Port %>
+        -  port: <%= @Node_RPCPort %>
+        -  port: <%= @NodeP2P_ListenAddr %>
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app: qubernetes
+      ports:
+        - port: <%= @TM_Port %>
+        - port: 9080
+        - port: <%= @Raft_Port %>
+        - port: <%= @Node_RPCPort %>
+        - port: <%= @NodeP2P_ListenAddr %>
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  <%= @Namespace %>
+  name: quorum-external-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: qubernetes
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: qubernetes
+      ports:
+        - port: <%= @TM_Port %>
+        - port: 9080
+        - port:  <%= @Node_RPCPort %>


### PR DESCRIPTION
If `NetworkPolicy: true` set in the minimal config, generate a k8s network policy for the quorum network / namespace to allow traffic in / out on the specified ports (RPC, Raft, TM, P2P).