### PR TITLE
Add optional annotations & storageclass to PVCs.

### DIFF
--- a/examples/config/qubernetes-pvc-annotations.yaml
+++ b/examples/config/qubernetes-pvc-annotations.yaml
@@ -1,0 +1,52 @@
+#namespace:
+#  name: quorum-test
+# number of nodes to deploy
+sep_deployment_files: true
+nodes:
+  number: 4
+service:
+  # NodePort | ClusterIP
+  type: NodePort
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  # base quorum data dir as set inside each container.
+  Node_DataDir: /etc/quorum/qdata
+  # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
+  # Either full or relative paths on the machine generating the config
+  Key_Dir_Base: out/config
+  Permissioned_Nodes_File: out/config/permissioned-nodes.json
+  Genesis_File: out/config/genesis.json
+  # related to quorum containers
+  quorum:
+    Raft_Port: 50401
+    # container images at https://hub.docker.com/u/quorumengineering/
+    Quorum_Version: 2.4.0
+  # related to transaction manager containers
+  tm:
+    # container images at https://hub.docker.com/u/quorumengineering/
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+    Port: 9001
+    Tessera_Config_Dir: out/config
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  storage:
+    PVC:
+      annotations:
+        volume.beta.kubernetes.io/storage-class: "YOUR_STORAGE_CLASS"
+      ## when redeploying cannot be less than previous values
+      Capacity: 5Gi
+# generic geth related options
+geth:
+  Node_RPCPort: 8545
+  NodeP2P_ListenAddr: 30303
+  network:
+    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
+    id: 1101
+    # public (true|false) is it a public network?
+    public: false
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\"

--- a/examples/config/qubernetes-pvc-storageclass.yaml
+++ b/examples/config/qubernetes-pvc-storageclass.yaml
@@ -1,0 +1,52 @@
+#namespace:
+#  name: quorum-test
+# number of nodes to deploy
+sep_deployment_files: true
+nodes:
+  number: 4
+service:
+  # NodePort | ClusterIP
+  type: NodePort
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  # base quorum data dir as set inside each container.
+  Node_DataDir: /etc/quorum/qdata
+  # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
+  # Either full or relative paths on the machine generating the config
+  Key_Dir_Base: out/config
+  Permissioned_Nodes_File: out/config/permissioned-nodes.json
+  Genesis_File: out/config/genesis.json
+  # related to quorum containers
+  quorum:
+    Raft_Port: 50401
+    # container images at https://hub.docker.com/u/quorumengineering/
+    Quorum_Version: 2.4.0
+  # related to transaction manager containers
+  tm:
+    # container images at https://hub.docker.com/u/quorumengineering/
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+    Port: 9001
+    Tessera_Config_Dir: out/config
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  storage:
+    PVC:
+      # optional storage class, if you don't know what this is,
+      storageClassName: my-csi-plugin
+      ## when redeploying cannot be less than previous values
+      Capacity: 5Gi
+# generic geth related options
+geth:
+  Node_RPCPort: 8545
+  NodeP2P_ListenAddr: 30303
+  network:
+    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
+    id: 1101
+    # public (true|false) is it a public network?
+    public: false
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\"

--- a/templates/k8s/persistent-volumes.yaml.erb
+++ b/templates/k8s/persistent-volumes.yaml.erb
@@ -5,8 +5,22 @@ def set_node_template_vars(values)
 end
 # default the capacity to 200Mi if not set in qubernetes.yaml file.
 @Capacity = "200Mi"
-if @config["quorum"]["storage"] && @config["quorum"]["storage"]["Capacity"]
-  @Capacity = @config["quorum"]["storage"]["Capacity"]
+@Annotations = []
+
+## TODO: changing the basic config to not longer use `type` under storage, as the only type supported not is PVC
+##       staying backwards compatible with the old configuration style for now, `storage: type: PVC` but this will
+##       be removed in the future and only `storage: PVC: [Annotations: Capacity]` will be supported.
+if @config["quorum"]["storage"]["PVC"]
+  @Storage_Config = @config["quorum"]["storage"]["PVC"]
+else
+  @Storage_Config = @config["quorum"]["storage"]
+end
+
+if @Storage_Config["Capacity"]
+  @Capacity =  @Storage_Config["Capacity"]
+end
+if @config["quorum"]["storage"]["PVC"] and @config["quorum"]["storage"]["PVC"]["annotations"]
+  @Annotations = @config["quorum"]["storage"]["PVC"]["annotations"]
 end
 -%>
 
@@ -29,6 +43,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: <%= @Node_UserIdent %>-quorum
   <%= @Namespace %>
+  annotations:
+<%- @Annotations.each do |annotation| -%>
+    <%= annotation[0] %>: <%= annotation[1] %>
+<%- end -%>
 spec:
   accessModes:
     - ReadWriteOnce
@@ -42,6 +60,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: <%= @Node_UserIdent %>-tm-pvc
   <%= @Namespace %>
+  annotations:
+<%- @Annotations.each do |annotation| -%>
+    <%= annotation[0] %>: <%= annotation[1] %>
+<%- end -%>
 spec:
   accessModes:
     - ReadWriteOnce
@@ -55,6 +77,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: <%= @Node_UserIdent %>-log-pvc
   <%= @Namespace %>
+  annotations:
+<%- @Annotations.each do |annotation| -%>
+    <%= annotation[0] %>: <%= annotation[1] %>
+<%- end -%>
 spec:
   accessModes:
     - ReadWriteOnce

--- a/templates/k8s/persistent-volumes.yaml.erb
+++ b/templates/k8s/persistent-volumes.yaml.erb
@@ -22,6 +22,9 @@ end
 if @config["quorum"]["storage"]["PVC"] and @config["quorum"]["storage"]["PVC"]["annotations"]
   @Annotations = @config["quorum"]["storage"]["PVC"]["annotations"]
 end
+if @config["quorum"]["storage"]["PVC"] and @config["quorum"]["storage"]["PVC"]["storageClassName"]
+   @Storage_Class_Name = "storageClassName: "+ @config["quorum"]["storage"]["PVC"]["storageClassName"]
+end
 -%>
 
 <%- if @Namespace != "" %>
@@ -48,6 +51,7 @@ metadata:
     <%= annotation[0] %>: <%= annotation[1] %>
 <%- end -%>
 spec:
+  <%= @Storage_Class_Name %>
   accessModes:
     - ReadWriteOnce
   resources:
@@ -65,6 +69,7 @@ metadata:
     <%= annotation[0] %>: <%= annotation[1] %>
 <%- end -%>
 spec:
+  <%= @Storage_Class_Name %>
   accessModes:
     - ReadWriteOnce
   resources:
@@ -82,6 +87,7 @@ metadata:
     <%= annotation[0] %>: <%= annotation[1] %>
 <%- end -%>
 spec:
+  <%= @Storage_Class_Name %>
   accessModes:
     - ReadWriteOnce
   resources:

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -31,20 +31,6 @@ end
 @Tm_Name               = @config["quorum"]["tm"]["Name"]
 # Storage for data directories, default PVC.
 @Storage_Type          = "PVC"
-# if storage is set set up the appropriate storage variable (host or PVC)
-if @config["quorum"]["storage"]
-  if @config["quorum"]["storage"]["Type"].upcase == "HOST"
-    @Storage_Type = "HOST"
-    # default DataDir for (hostPath) if none is set.
-    @DataDir = "/var/lib/docker/geth-storage"
-    if @config["quorum"]["storage"]["Data_Dir"]
-      @DataDir = @config["quorum"]["storage"]["Data_Dir"]
-    end
-  # Persistent_Volume_Claim
-  elsif @config["quorum"]["storage"]["Type"].upcase == "PVC"
-    @Storage_Type = "PVC"
-  end
-end
 %>
 
 # The quorum deployment consists of


### PR DESCRIPTION
- Added optional annotations on PVC.
- Added optional storageClassName for PVCs to config.
- (clean up) Removed dead code in `quorum-deployment.yaml.erb` which was left over from when `hostPath` was support. `hostPath` is no longer supported as a storage option, so remove logic around it.

---
*  Added optional storageClassName for PVCs to config.

Allow the config to specific the storageClassName to use with the
PVC, currently both `storageClassName` and the annotation `volume.beta.kubernetes.io/storage-class` are supported, but the annotation `volume.beta.kubernetes.io/storage-class` won't be supported by Kubernetes in the future
see: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims

An example of using `storageClassName` in the config file has been added here: examples/config/qubernetes-pvc-storageclass.yaml

`storageClassName` is optional, so if it is left out, the default for the cluster will be select by the underlying k8s platform.

* Add optional storageClassName for PVCs to config.
Allow for configuring annotations on the K8s PVC generation, e.g. volume.beta.kubernetes.io/storage-class, which can allow for setting various storage classes, or other policies that the underlying k8s cluster may require.

changing the config requirements in the qubernetes.yaml from
```
 storage:
    # PVC (Persistent_Volume_Claim - tested with GCP).
    Type: PVC
```
to
```
  storage:
    PVC:
      annotations:
        volume.beta.kubernetes.io/storage-class: "YOUR_STORAGE_CLASS"
      ## when redeploying cannot be less than previous values
      Capacity: 5Gi
```
as PVC is the only support storage for now. For now, remain backwards compatible with the old configuration syntax, but this should be removed in the future.