### PR TITLE
Add support for k8s securityContext on deployments.

### DIFF
--- a/contracts/runscript.sh
+++ b/contracts/runscript.sh
@@ -1,2 +1,2 @@
 #!/bin/ash
-PRIVATE_CONFIG=$TM_HOME/tm.ipc geth --exec "loadScript(\"$1\")" attach ipc:$QUORUM_HOME/dd/geth.ipc
+PRIVATE_CONFIG=$TM_HOME/tm.ipc geth --exec "loadScript(\"$1\")" attach --datadir $QUORUM_DATA_DIR ipc:$QUORUM_DATA_DIR/geth.ipc

--- a/examples/config/qubernetes-security-context.yaml
+++ b/examples/config/qubernetes-security-context.yaml
@@ -1,0 +1,63 @@
+#namespace:
+# name: quorum-test
+# number of nodes to deploy
+sep_deployment_files: true
+nodes:
+  number: 3
+service:
+  # NodePort | ClusterIP | LoadBalancer
+  type: NodePort
+  Ingress:
+    # OneToMany | OneToOne
+    Strategy: OneToOne
+    Host: "quorum.testnet.com"
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  # base quorum data dir as set inside each container.
+  Node_DataDir: /etc/quorum/qdata
+  # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
+  # Either full or relative paths on the machine generating the config
+  Key_Dir_Base: out/config
+  Permissioned_Nodes_File: out/config/permissioned-nodes.json
+  Genesis_File: out/config/genesis.json
+  # related to quorum containers
+  quorum:
+    Raft_Port: 50401
+    # container images at https://hub.docker.com/u/quorumengineering/
+    Quorum_Version: 2.2.5
+  # related to transaction manager containers
+  tm:
+    # container images at https://hub.docker.com/u/quorumengineering/
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.11
+    Port: 9001
+    Tessera_Config_Dir: out/config
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP
+  # The data dir is persisted here
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 200Mi
+# generic geth related options
+geth:
+  Node_RPCPort: 8545
+  NodeP2P_ListenAddr: 30303
+  network:
+    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
+    id: 1101
+    # public (true|false) is it a public network?
+    public: false
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\"
+k8s:
+  # optionally  allow a security context to be set for the deployment, e.g. can the user have root access?
+  securityContext:
+    runAsUser: 430
+    fsGroup: 430
+    supplementalGroups: [666,777]

--- a/helpers/container/geth-attach.sh
+++ b/helpers/container/geth-attach.sh
@@ -4,4 +4,4 @@
 # outside the container
 # kubectl exec -it $POD -c quorum -- /geth-helpers/geth-attach.sh
 echo "connecting to geth $QHOME"
-geth attach $QHOME/dd/geth.ipc
+geth attach --datadir $QUORUM_DATA_DIR $QUORUM_DATA_DIR/geth.ipc

--- a/helpers/container/geth-exec.sh
+++ b/helpers/container/geth-exec.sh
@@ -12,4 +12,4 @@ fi
 # https://github.com/ethereum/go-ethereum/issues/16905
 # to avoid warning being returned
 # "WARN [02-20|00:21:04.382] Sanitizing cache to Go's GC limits  provided=1024 updated=663"
-geth --exec $GETH_CMD  --cache=16   attach $QHOME/dd/geth.ipc
+geth --exec $GETH_CMD  --cache=16 attach --datadir $QUORUM_DATA_DIR $QUORUM_DATA_DIR/geth.ipc

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -33,6 +33,12 @@ end
 @Storage_Type          = "PVC"
 %>
 
+<%
+ @Security_Context = []
+ if @config["k8s"] and @config["k8s"]["securityContext"]
+   @Security_Context = @config["k8s"]["securityContext"]
+ end
+%>
 # The quorum deployment consists of
 # 1. the transaction manager / private tx container (constellation or tessera)
 # 2. the quorum node container
@@ -58,6 +64,10 @@ spec:
         tier: backend
         name: <%= @Node_UserIdent %>-deployment
     spec:
+      securityContext:
+      <%- @Security_Context.each do |entry| -%>
+        <%= entry[0] %>: <%= entry[1] %>
+      <%- end -%>
       initContainers:
       - name: quorum-genesis-init-container
         image: <%= @Quorum_Docker_Repo %>/quorum:<%= @Quorum_Version %>
@@ -202,7 +212,12 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
  <%- if @Tm_Name == "tessera" -%>
+   <%- if @Security_Context -%> <%# if a security context is set, assume we cannot install packages, e.g. curl, so sleep for 60 to give the TM time to startup. %>
+           echo sleeping for 60 seconds to wait for the transaction manager to startup.
+           sleep 60;
+   <%- else -%>  <%# if a security context not set, assume we can install packages, e.g. curl, we can do a check to see when the TM comes up. %>
            until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:<%= @Tm_Port %>/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
+   <%- end -%>
            echo transaction manager is up;
  <%- else -%>
            sleep 5;


### PR DESCRIPTION
* If the k8s securityContext is set in the config add it to the deployments, at the top level.
see an example: examples/config/qubernetes-security-context.yaml
ks:
  securityContext:
    runAsUser: 430
...
note: not supporting the additions of capabilities at this time.
note: not supporting pod level overriding securityContext at this time.

* add --datadir to all geth attach commands, as if the securitycontext is set limiting the user's privileges. e.g. non root,   --datadir is required or else the following error will be seen:
Fatal: Failed to start the JavaScript console: mkdir /.ethereum: permission denied