### PR TITLE
Adding docker image labels and build helper script.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM ubuntu:16.04
 
+ARG COMMIT=""
+ARG QUBES_VERSION=""
+ARG BUILD_DATE=""
+
+# Label according to  https://github.com/opencontainers/image-spec
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${COMMIT}
+LABEL org.opencontainers.image.source="https://github.com/jpmorganchase/qubernetes.git"
+LABEL org.opencontainers.image.title="qubernetes"
+LABEL org.opencontainers.image.version=${QUBES_VERSION}
+
 RUN apt-get update \
     && apt-get --no-install-recommends install -y apt-utils curl wget git tree ne software-properties-common apt-transport-https ca-certificates build-essential
 
@@ -19,3 +30,7 @@ RUN cd /usr/bin && curl -L https://github.com/jpmorganchase/constellation/releas
 
 WORKDIR /qubernetes
 COPY . .
+
+# set commit SHA and QUBES_VERSION as ENV vars in last layer
+ENV COMMIT_SHA=${COMMIT}
+ENV QUBES_VERSION=${QUBES_VERSION}

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env sh
+
+# Helper for building dockerhub images from specified git tags.
+# ./docker-build.sh v0.1.1 quorumengineering/qubernetes
+
+# To see labels:
+# docker image inspect --format='' $IMAGE_NAME
+
+# For debugging all env vars
+# printenv
+
+IMAGE_NAME="quorumengineering/qubernetes"
+VERSION_TAG="latest"
+
+usage() {
+  echo "usage: "
+  echo "  docker-build.sh VERSION IMAGE_NAME"
+  echo "  docker-build.sh v0.1.1 quorumengineering/qubernetes"
+  echo
+}
+
+if [[ $# -lt 1 ]]; then
+  echo " No version or image_name passed in, using defaults. "
+  echo
+  usage
+  echo
+fi
+
+if [[ $# -gt 0 ]]; then
+  VERSION_TAG=$1
+fi
+
+if [[ $# -gt 1 ]]; then
+  IMAGE_NAME=$2
+fi
+
+echo "building docker image: "
+echo "  image: $IMAGE_NAME:$VERSION_TAG "
+echo "  qube version: $VERSION_TAG"
+echo
+
+echo "docker build --no-cache --pull --build-arg=COMMIT=$(git rev-parse --short HEAD) --build-arg=QUBES_VERSION=$VERSION_TAG --build-arg=BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $IMAGE_NAME:$VERSION_TAG ."
+docker build --no-cache --pull --build-arg=COMMIT=$(git rev-parse --short HEAD) --build-arg=QUBES_VERSION=$VERSION_TAG --build-arg=BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $IMAGE_NAME:$VERSION_TAG .


### PR DESCRIPTION
When building docker images (from a git tag) to be pushed to docker hub, certain docker image labels should be set to help with integrity, clarity, self documenting, etc. adding a helper script (docker-build.sh) which sets and passes in the label and env vars, e.g. VERSION (tag),
COMMIT_SHA of the image was built from.

Following OCI spec: https://github.com/opencontainers/image-spec/blob/master/annotations.md