### PR TITLE
Reduce required config values by setting reasonable defaults.

### DIFF
--- a/examples/config/qubes-minimal.yaml
+++ b/examples/config/qubes-minimal.yaml
@@ -1,0 +1,18 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+
+# number of nodes to deploy
+nodes:
+  number: 4
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  quorum:
+    Quorum_Version: 2.2.5
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.11

--- a/qubernetes
+++ b/qubernetes
@@ -131,28 +131,24 @@ end
 
 @base_template_path = "templates/k8s"
 #puts (sed_string)
-puts "PVC start"
 if @Storage_Type == "PVC"
   File.open("out/00-quorum-persistent-volumes.yaml", "w") do |f|
     f.puts (ERB.new(File.read(@base_template_path + "/persistent-volumes.yaml.erb"), nil, "-").result)
   end
 end
-puts "PVC end"
 File.open("out/01-quorum-genesis.yaml", "w") do |f|
   f.puts (ERB.new(File.read(@base_template_path + "/quorum-genesis-config.yaml.erb"), nil, "-").result)
 end
 File.open("out/02-quorum-shared-config.yaml", "w") do |f|
   f.puts (ERB.new(File.read(@base_template_path + "/quorum-shared-config.yaml.erb"), nil, "-").result)
 end
-
 # Create the service resources
 File.open("out/03.0-quorum-services.yaml", "w") do |f|
   f.puts (ERB.new(File.read(@base_template_path + "/quorum-services.yaml.erb"), nil, "-").result)
 end
 
-
 # Create the Ingress resources if they are configured
-if @config["service"]["Ingress"]
+if @config["service"] and @config["service"]["Ingress"]
   File.open("out/03.1-quorum-ingress.yaml", "w") do |f|
     f.puts (ERB.new(File.read(@base_template_path + "/quorum-ingress.yaml.erb"), nil, "-").result)
   end
@@ -164,7 +160,7 @@ File.open("out/04-quorum-keyconfigs.yaml", "w") do |f|
 end
 
 # if a network policy was requested create one for the namespace (NetworkPolicy = true in yaml config)
-if @config["service"]["NetworkPolicy"]
+if  @config["service"] and @config["service"]["NetworkPolicy"]
   File.open("out/05-quorum-network-policy.yaml", "w") do |f|
     f.puts (ERB.new(File.read(@base_template_path + "/network-policy.yaml.erb"), nil, "-").result)
   end

--- a/qubernetes
+++ b/qubernetes
@@ -17,9 +17,27 @@ puts "using config file: " + @CONFIG_FILE
 @config                = YAML.load_file(@CONFIG_FILE)
 
 @nodes                 = YAML.load_file("nodes.yaml")["nodes"]
-@Raft_Port             = @config["quorum"]["quorum"]["Raft_Port"]
-@Node_RPCPort          = @config["geth"]["Node_RPCPort"]
-@NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
+
+# default the ports if they aren't set
+@Raft_Port = 50401
+if @config["quorum"]["quorum"]["Raft_Port"]
+  @Raft_Port = @config["quorum"]["quorum"]["Raft_Port"]
+end
+
+@Tm_Port = 9001
+if @config["quorum"]["tm"]["Port"]
+  @Tm_Port = @config["quorum"]["tm"]["Port"]
+end
+
+@Node_RPCPort = 8545
+if @config["geth"]["Node_RPCPort"]
+  @Node_RPCPort = @config["geth"]["Node_RPCPort"]
+end
+
+@NodeP2P_ListenAddr = 30303
+if @config["geth"]["NodeP2P_ListenAddr"]
+  @NodeP2P_ListenAdd = @config["geth"]["NodeP2P_ListenAddr"]
+end
 
 
 # Generate deployments in a single file, or in separate files.

--- a/qubernetes
+++ b/qubernetes
@@ -18,7 +18,39 @@ puts "using config file: " + @CONFIG_FILE
 
 @nodes                 = YAML.load_file("nodes.yaml")["nodes"]
 
-# default the ports if they aren't set
+## set defaults for config if not set, else use the values from the config.
+
+# used in deployment.yaml.erb to set quorum data dir.
+@Node_DataDir = "/etc/quorum/qdata"
+if @config["quorum"]["Node_DataDir"]
+  @Node_DataDir = @config["quorum"]["Node_DataDir"]
+end
+
+# used by quorum-shared-config.yaml.erb and quorum-keystore.yaml.erb to load keys.
+@Key_Dir_Base = "out/config"
+if @config["quorum"]["Key_Dir_Base"]
+  @Key_Dir_Base  = @config["quorum"]["Key_Dir_Base"]
+end
+
+# used by quorum-shared-config.yaml.erb to load the permissioned-nodes.json in configmaps
+@Permissioned_Nodes_File = "out/config/permissioned-nodes.json"
+if @config["quorum"]["Permissioned_Nodes_File"]
+  @Permissioned_Nodes_File = @config["quorum"]["Permissioned_Nodes_File"]
+end
+
+# used by quorum-genesis-config.yaml.erb and quorum-shared-config.yaml.erb
+@Genesis_File = "out/config/genesis.json"
+if @config["quorum"]["Genesis_File"]
+  @Genesis_File = @config["quorum"]["Genesis_File"]
+end
+
+# used in quorum-shared-config.yaml.erb to make tessera config available to deployments.
+@Tessera_Config_Dir = "out/config"
+if @config["quorum"]["tm"]["Tessera_Config_Dir"]
+  @Tessera_Config_Dir = @config["quorum"]["tm"]["Tessera_Config_Dir"]
+end
+
+## default the ports if they aren't set
 @Raft_Port = 50401
 if @config["quorum"]["quorum"]["Raft_Port"]
   @Raft_Port = @config["quorum"]["quorum"]["Raft_Port"]

--- a/qubernetes
+++ b/qubernetes
@@ -62,12 +62,12 @@ if @config["quorum"]["tm"]["Port"]
 end
 
 @Node_RPCPort = 8545
-if @config["geth"]["Node_RPCPort"]
+if @config["geth"] and @config["geth"]["Node_RPCPort"]
   @Node_RPCPort = @config["geth"]["Node_RPCPort"]
 end
 
 @NodeP2P_ListenAddr = 30303
-if @config["geth"]["NodeP2P_ListenAddr"]
+if @config["geth"] and @config["geth"]["NodeP2P_ListenAddr"]
   @NodeP2P_ListenAdd = @config["geth"]["NodeP2P_ListenAddr"]
 end
 
@@ -131,6 +131,7 @@ end
 
 @base_template_path = "templates/k8s"
 #puts (sed_string)
+puts "PVC"
 if @Storage_Type == "PVC"
   File.open("out/00-quorum-persistent-volumes.yaml", "w") do |f|
     f.puts (ERB.new(File.read(@base_template_path + "/persistent-volumes.yaml.erb"), nil, "-").result)
@@ -165,7 +166,7 @@ if  @config["service"] and @config["service"]["NetworkPolicy"]
     f.puts (ERB.new(File.read(@base_template_path + "/network-policy.yaml.erb"), nil, "-").result)
   end
 end
-
+puts "deployments"
 @Kubectl_Cmd="  $> kubectl apply -f out"
 if @sep_deployment_files
  `mkdir -p out/deployments`

--- a/quorum-config
+++ b/quorum-config
@@ -22,8 +22,21 @@ puts "using config file: " + @CONFIG_FILE
 
 @Tessera_Config_Dir         = @config["quorum"]["tm"]["Tessera_Config_Dir"]
 
-@Node_RPCPort               = @config["geth"]["Node_RPCPort"]
-@NodeP2P_ListenAddr         = @config["geth"]["NodeP2P_ListenAddr"]
+## set ports needed for the quorum templates
+# Tm_Port used in tessera config templates
+@Tm_Port = 9001
+if @config["quorum"]["tm"]["Port"]
+  @Tm_Port = @config["quorum"]["tm"]["Port"]
+end
+# used by permissioned-nodes.json.erb to set enode URLs
+@Raft_Port = 50401
+if @config["quorum"]["quorum"]["Raft_Port"]
+  @Raft_Port = @config["quorum"]["quorum"]["Raft_Port"]
+end
+@NodeP2P_ListenAddr = 30303
+if @config["geth"]["NodeP2P_ListenAddr"]
+  @NodeP2P_ListenAdd = @config["geth"]["NodeP2P_ListenAddr"]
+end
 
 #####################################################
 # Generate genesis.json and permissioned-nodes.json

--- a/quorum-config
+++ b/quorum-config
@@ -16,11 +16,37 @@ puts "using config file: " + @CONFIG_FILE
 @config     = YAML.load_file(@CONFIG_FILE)
 @nodes      = YAML.load_file("nodes.yaml")["nodes"]
 
-@Raft_Port                  = @config["quorum"]["quorum"]["Raft_Port"]
-@Permissioned_Nodes_File    = @config["quorum"]["Permissioned_Nodes_File"]
-@Genesis_File               = @config["quorum"]["Genesis_File"]
+## set defaults for config if not set, else use the values from the config.
 
-@Tessera_Config_Dir         = @config["quorum"]["tm"]["Tessera_Config_Dir"]
+# directory where the genesis.json will be stored after it is generated.
+@Genesis_File = "out/config/genesis.json"
+if @config["quorum"]["Genesis_File"]
+  @Genesis_File = @config["quorum"]["Genesis_File"]
+end
+
+# used by genesis.json.erb, gen-keys.sh.erb, and .
+@Key_Dir_Base = "out/config"
+if @config["quorum"]["Key_Dir_Base"]
+  @Key_Dir_Base  = @config["quorum"]["Key_Dir_Base"]
+end
+
+# used in tessera-config-*.json.erb(s)
+@Node_DataDir = "/etc/quorum/qdata"
+if @config["quorum"]["Node_DataDir"]
+  @Node_DataDir = @config["quorum"]["Node_DataDir"]
+end
+
+# directory where the permissioned-node.json will be stored after it is generated.
+@Permissioned_Nodes_File = "out/config/permissioned-nodes.json"
+if @config["quorum"]["Permissioned_Nodes_File"]
+  @Permissioned_Nodes_File = @config["quorum"]["Permissioned_Nodes_File"]
+end
+
+# directory where the tessera-config.json files. will be stored after it is generated.
+@Tessera_Config_Dir = "out/config"
+if @config["quorum"]["tm"]["Tessera_Config_Dir"]
+  @Tessera_Config_Dir = @config["quorum"]["tm"]["Tessera_Config_Dir"]
+end
 
 ## set ports needed for the quorum templates
 # Tm_Port used in tessera config templates

--- a/quorum-config
+++ b/quorum-config
@@ -60,7 +60,7 @@ if @config["quorum"]["quorum"]["Raft_Port"]
   @Raft_Port = @config["quorum"]["quorum"]["Raft_Port"]
 end
 @NodeP2P_ListenAddr = 30303
-if @config["geth"]["NodeP2P_ListenAddr"]
+if @config["geth"] and @config["geth"]["NodeP2P_ListenAddr"]
   @NodeP2P_ListenAdd = @config["geth"]["NodeP2P_ListenAddr"]
 end
 

--- a/quorum-keygen
+++ b/quorum-keygen
@@ -17,6 +17,12 @@ puts "using config file: " + @CONFIG_FILE
 
 @base_template_path = "templates/quorum"
 
+# used by gen-keys.sh.erb
+@Key_Dir_Base = "out/config"
+if @config["quorum"]["Key_Dir_Base"]
+  @Key_Dir_Base  = @config["quorum"]["Key_Dir_Base"]
+end
+
 File.open(@base_template_path + "/gen-node-keys.sh", "w") do |f|
   f.puts (ERB.new(File.read(@base_template_path + "/gen-keys.sh.erb"), nil, "-").result)
 end

--- a/templates/k8s/network-policy.yaml.erb
+++ b/templates/k8s/network-policy.yaml.erb
@@ -1,8 +1,3 @@
-<%
-  @TM_Port               = @config["quorum"]["tm"]["Port"]
-  @Node_RPCPort          = @config["geth"]["Node_RPCPort"]
-  @NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
- %>
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/k8s/persistent-volumes.yaml.erb
+++ b/templates/k8s/persistent-volumes.yaml.erb
@@ -6,31 +6,31 @@ end
 # default the capacity to 200Mi if not set in qubernetes.yaml file.
 @Capacity = "200Mi"
 @Annotations = []
-
 ## TODO: changing the basic config to not longer use `type` under storage, as the only type supported not is PVC
 ##       staying backwards compatible with the old configuration style for now, `storage: type: PVC` but this will
 ##       be removed in the future and only `storage: PVC: [Annotations: Capacity]` will be supported.
-if @config["quorum"]["storage"] and @config["quorum"]["storage"]["PVC"]
-  @Storage_Config = @config["quorum"]["storage"]["PVC"]
-  @Capacity =  @Storage_Config["Capacity"]
-else
-  @Storage_Config = @config["quorum"]["storage"]
-  @Capacity =  @Storage_Config["Capacity"]
-end
 
-#if @Storage_Config["Capacity"]
-#  @Capacity =  @Storage_Config["Capacity"]
-#end
+# if the user set storage params, override the defaults, and add their config.
+if @config["quorum"]["storage"]
+  if @config["quorum"]["storage"]["PVC"]
+    @Storage_Config = @config["quorum"]["storage"]["PVC"]
+    @Capacity =  @Storage_Config["Capacity"]
+  else
+    @Storage_Config = @config["quorum"]["storage"]
+    @Capacity =  @Storage_Config["Capacity"]
+  end
 
-if @config["quorum"]["storage"]["PVC"]
+  puts "got storage config"
+  if @Storage_Config["PVC"]
 
- if @config["quorum"]["storage"]["PVC"]["annotations"]
-  @Annotations = @config["quorum"]["storage"]["PVC"]["annotations"]
- end
- if  @config["quorum"]["storage"]["PVC"]["storageClassName"]
-  @Storage_Class_Name = "storageClassName: "+ @config["quorum"]["storage"]["PVC"]["storageClassName"]
- end
+   if @Storage_Config["PVC"]["annotations"]
+    @Annotations = @Storage_Config["PVC"]["annotations"]
+   end
+   if  @Storage_Config["PVC"]["storageClassName"]
+    @Storage_Class_Name = "storageClassName: "+ @Storage_Config["PVC"]["storageClassName"]
+   end
 
+  end
 end
 -%>
 

--- a/templates/k8s/persistent-volumes.yaml.erb
+++ b/templates/k8s/persistent-volumes.yaml.erb
@@ -10,20 +10,27 @@ end
 ## TODO: changing the basic config to not longer use `type` under storage, as the only type supported not is PVC
 ##       staying backwards compatible with the old configuration style for now, `storage: type: PVC` but this will
 ##       be removed in the future and only `storage: PVC: [Annotations: Capacity]` will be supported.
-if @config["quorum"]["storage"]["PVC"]
+if @config["quorum"]["storage"] and @config["quorum"]["storage"]["PVC"]
   @Storage_Config = @config["quorum"]["storage"]["PVC"]
+  @Capacity =  @Storage_Config["Capacity"]
 else
   @Storage_Config = @config["quorum"]["storage"]
-end
-
-if @Storage_Config["Capacity"]
   @Capacity =  @Storage_Config["Capacity"]
 end
-if @config["quorum"]["storage"]["PVC"] and @config["quorum"]["storage"]["PVC"]["annotations"]
+
+#if @Storage_Config["Capacity"]
+#  @Capacity =  @Storage_Config["Capacity"]
+#end
+
+if @config["quorum"]["storage"]["PVC"]
+
+ if @config["quorum"]["storage"]["PVC"]["annotations"]
   @Annotations = @config["quorum"]["storage"]["PVC"]["annotations"]
-end
-if @config["quorum"]["storage"]["PVC"] and @config["quorum"]["storage"]["PVC"]["storageClassName"]
-   @Storage_Class_Name = "storageClassName: "+ @config["quorum"]["storage"]["PVC"]["storageClassName"]
+ end
+ if  @config["quorum"]["storage"]["PVC"]["storageClassName"]
+  @Storage_Class_Name = "storageClassName: "+ @config["quorum"]["storage"]["PVC"]["storageClassName"]
+ end
+
 end
 -%>
 

--- a/templates/k8s/persistent-volumes.yaml.erb
+++ b/templates/k8s/persistent-volumes.yaml.erb
@@ -21,16 +21,14 @@ if @config["quorum"]["storage"]
   end
 
   puts "got storage config"
-  if @Storage_Config["PVC"]
 
-   if @Storage_Config["PVC"]["annotations"]
-    @Annotations = @Storage_Config["PVC"]["annotations"]
-   end
-   if  @Storage_Config["PVC"]["storageClassName"]
-    @Storage_Class_Name = "storageClassName: "+ @Storage_Config["PVC"]["storageClassName"]
-   end
-
+  if @Storage_Config["annotations"]
+   @Annotations = @Storage_Config["annotations"]
   end
+  if  @Storage_Config["storageClassName"]
+   @Storage_Class_Name = "storageClassName: "+ @Storage_Config["storageClassName"]
+  end
+
 end
 -%>
 

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -3,8 +3,6 @@
 @Service_Prefix = (@Node_UserIdent.upcase).gsub("-", "_")
 @Geth_Verbosity        = @config["geth"]["verbosity"]
 @Geth_Network_Id       = @config["geth"]["network"]["id"]
-@Node_RPCPort           = @config["geth"]["Node_RPCPort"]
-@NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
 
 if @config["geth"]["Geth_Startup_Params"]
   @Geth_Startup_Params   = @config["geth"]["Geth_Startup_Params"]
@@ -27,7 +25,6 @@ else
  @Tm_Docker_Repo =  "quorumengineering"
 end
 @Tm_Version            = @config["quorum"]["tm"]["Tm_Version"]
-@Tm_Port               = @config["quorum"]["tm"]["Port"]
 @Tm_Name               = @config["quorum"]["tm"]["Name"]
 # Storage for data directories, default PVC.
 @Storage_Type          = "PVC"

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -1,10 +1,18 @@
 #<%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/enode").each do |line| -%><%= line -%><% end -%>
 <%
 @Service_Prefix = (@Node_UserIdent.upcase).gsub("-", "_")
-@Geth_Verbosity        = @config["geth"]["verbosity"]
-@Geth_Network_Id       = @config["geth"]["network"]["id"]
 
-if @config["geth"]["Geth_Startup_Params"]
+@Geth_Verbosity = 9
+if @config["geth"] and @config["geth"]["verbosity"]
+  @Geth_Verbosity = @config["geth"]["verbosity"]
+end
+
+@Geth_Network_Id  = 1101
+if @config["geth"] and @config["geth"]["network"] and @config["geth"]["network"]["id"]
+  @Geth_Network_Id = @config["geth"]["network"]["id"]
+end
+
+if @config["geth"] and @config["geth"]["Geth_Startup_Params"]
   @Geth_Startup_Params   = @config["geth"]["Geth_Startup_Params"]
 else
   @Geth_Startup_Params   = ""

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -1,4 +1,4 @@
-#<%- File.readlines("#{@Keystore_Dir}/#{@Node_Key_Dir}/enode").each do |line| -%><%= line -%><% end -%>
+#<%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/enode").each do |line| -%><%= line -%><% end -%>
 <%
 @Service_Prefix = (@Node_UserIdent.upcase).gsub("-", "_")
 @Geth_Verbosity        = @config["geth"]["verbosity"]
@@ -10,7 +10,6 @@ else
   @Geth_Startup_Params   = ""
 end
 
-@Node_DataDir          = @config["quorum"]["Node_DataDir"]
 @Quorum_Version        = @config["quorum"]["quorum"]["Quorum_Version"]
 # default quorumengineering/quorum
 if @config["quorum"]["quorum"]["Docker_Repo"]
@@ -209,7 +208,7 @@ spec:
 
            chmod 644 $QUORUM_DATA_DIR/keystore/key;
  <%- if @Tm_Name == "tessera" -%>
-   <%- if @Security_Context -%> <%# if a security context is set, assume we cannot install packages, e.g. curl, so sleep for 60 to give the TM time to startup. %>
+   <%- if @Security_Context != [] -%> <%# if a security context is set, assume we cannot install packages, e.g. curl, so sleep for 60 to give the TM time to startup. %>
            echo sleeping for 60 seconds to wait for the transaction manager to startup.
            sleep 60;
    <%- else -%>  <%# if a security context not set, assume we can install packages, e.g. curl, we can do a check to see when the TM comes up. %>
@@ -265,7 +264,7 @@ spec:
         - name: THIS_NODE_ID
           value: <%= @Node_UserIdent%>
         - name: THIS_ENODE
-          value: <%- File.readlines("#{@Keystore_Dir}/#{@Node_Key_Dir}/enode").each do |line| -%><%= line -%><% end -%>
+          value: <%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/enode").each do |line| -%><%= line -%><% end -%>
         volumeMounts:
         - name: genesis-config-persistent-storage
           mountPath: /etc/quorum/genesis/genesis-geth.json

--- a/templates/k8s/quorum-genesis-config.yaml.erb
+++ b/templates/k8s/quorum-genesis-config.yaml.erb
@@ -1,7 +1,3 @@
-<%-
- @Genesis_File = @config["quorum"]["Genesis_File"]
-%>
-
 <%- if @Namespace != "" %>
 apiVersion: v1
 kind: Namespace

--- a/templates/k8s/quorum-ingress.yaml.erb
+++ b/templates/k8s/quorum-ingress.yaml.erb
@@ -4,11 +4,6 @@ def set_node_template_vars(values)
     return
 end
 
-@Service_Prefix        = (@Node_UserIdent.upcase).gsub("-", "_")
-@TM_Port               = @config["quorum"]["tm"]["Port"]
-@Node_RPCPort          = @config["geth"]["Node_RPCPort"]
-@NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
-
 if @config["service"]["Ingress"] then
    @Ingress = true
    # OneForAll

--- a/templates/k8s/quorum-keystore.yaml.erb
+++ b/templates/k8s/quorum-keystore.yaml.erb
@@ -10,7 +10,6 @@ def set_node_template_vars(values)
 end
 
 # keys are named the same inside their respective directories.
-@Keystore_Dir = @config["quorum"]["Key_Dir_Base"]
 -%>
 
 
@@ -31,12 +30,12 @@ metadata:
     name: <%= @Node_UserIdent %>-tm-key-config
 data:
   tm.key: |-
-<%- File.readlines("#{@Keystore_Dir}/#{@Node_Key_Dir}/tm.key").each do |line| -%>
+<%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/tm.key").each do |line| -%>
     <%= line -%>
 <% end -%>
 
   tm.pub: |-
-<%- File.readlines("#{@Keystore_Dir}/#{@Node_Key_Dir}/tm.pub").each do |line| -%>
+<%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/tm.pub").each do |line| -%>
     <%= line -%>
 <% end -%>
 
@@ -53,7 +52,7 @@ metadata:
     name: <%= @Node_UserIdent %>-nodekey-config
 data:
   nodekey: |
-<%- File.readlines("#{@Keystore_Dir}/#{@Node_Key_Dir}/nodekey").each do |line| -%>
+<%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/nodekey").each do |line| -%>
     <%= line -%>
 <% end -%>
 
@@ -70,7 +69,7 @@ metadata:
     name: <%= @Node_UserIdent %>-enode-config
 data:
   enode: |
-<%- File.readlines("#{@Keystore_Dir}/#{@Node_Key_Dir}/enode").each do |line| -%>
+<%- File.readlines("#{@Key_Dir_Base}/#{@Node_Key_Dir}/enode").each do |line| -%>
     <%= line -%>
 <% end -%>
 
@@ -88,7 +87,7 @@ metadata:
 data:
   key: |-
 
-<%- @Keystore_File=Dir[@Keystore_Dir + "/" + @Node_Key_Dir + "/UTC*"][0] %>
+<%- @Keystore_File=Dir[@Key_Dir_Base + "/" + @Node_Key_Dir + "/UTC*"][0] %>
 <%- File.readlines("#{@Keystore_File}").each do |line| -%>
     <%= line -%>
 <% end -%>

--- a/templates/k8s/quorum-services.yaml.erb
+++ b/templates/k8s/quorum-services.yaml.erb
@@ -6,7 +6,11 @@ def set_node_template_vars(values)
 end
 
 # NodePort | ClusterIP | Loadbalancer
-@Service_Type          = @config["service"]["type"]
+# default to NodePort if not set
+@Service_Type = "NodePort"
+if @config["service"] and  @config["service"]["type"]
+ @Service_Type = @config["service"]["type"]
+end
 -%>
 
 <%- @nodes.each do |node| -%>
@@ -27,7 +31,7 @@ spec:
     tier: backend
     name: <%= @Node_UserIdent %>-deployment
   # NodePort | ClusterIP | Loadbalancer
-  type: <%= @config["service"]["type"] %>
+  type: <%= @Service_Type  %>
   ports:
     - name: tm-manager 
       protocol: TCP

--- a/templates/k8s/quorum-services.yaml.erb
+++ b/templates/k8s/quorum-services.yaml.erb
@@ -5,10 +5,6 @@ def set_node_template_vars(values)
     return
 end
 
-@Service_Prefix        = (@Node_UserIdent.upcase).gsub("-", "_")
-@TM_Port               = @config["quorum"]["tm"]["Port"]
-@Node_RPCPort          = @config["geth"]["Node_RPCPort"]
-@NodeP2P_ListenAddr    = @config["geth"]["NodeP2P_ListenAddr"]
 # NodePort | ClusterIP | Loadbalancer
 @Service_Type          = @config["service"]["type"]
 -%>
@@ -35,8 +31,8 @@ spec:
   ports:
     - name: tm-manager 
       protocol: TCP
-      port: <%= @TM_Port %>
-      targetPort: <%= @TM_Port %>
+      port: <%= @Tm_Port %>
+      targetPort: <%= @Tm_Port %>
     # default 8545
     - name: tm-tessera-third-part
       protocol: TCP

--- a/templates/k8s/quorum-shared-config.yaml.erb
+++ b/templates/k8s/quorum-shared-config.yaml.erb
@@ -1,12 +1,3 @@
-<%-
- @Permissioned_Nodes_File    = @config["quorum"]["Permissioned_Nodes_File"]
- @Genesis_File               = @config["quorum"]["Genesis_File"]
- @Tessera_Config_Dir         = @config["quorum"]["tm"]["Tessera_Config_Dir"]
-
- # keys are named the same inside their respective directories.
- @Keystore_Dir = @config["quorum"]["Key_Dir_Base"]
-%>
-
 # kubectl create configmap game-config --from-file=configure-pod-container/dd1/key
 apiVersion: v1
 kind: ConfigMap
@@ -72,7 +63,7 @@ data:
 # assumes that at least 2 nodes are being deployed.
   private_contract.js: |-
 <%-  tm_key2 = "NOT_SET" -%>
-<%- File.readlines("#{@Keystore_Dir}/key2/tm.pub").each do |line| -%>
+<%- File.readlines("#{@Key_Dir_Base}/key2/tm.pub").each do |line| -%>
 <% tm_key2 = line %>
 <% end -%>
 <%- File.readlines("contracts/private_contract.js").each do |line| -%>

--- a/templates/quorum/gen-keys.sh.erb
+++ b/templates/quorum/gen-keys.sh.erb
@@ -8,7 +8,6 @@ def set_node_template_vars(values)
 end
 -%>
 
-<% @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"] %>
 <% @Node_Dirs = "" %>
 
 <%- @nodes.each do |node|

--- a/templates/quorum/genesis.json.erb
+++ b/templates/quorum/genesis.json.erb
@@ -5,7 +5,10 @@ def set_node_template_vars(values)
     return
 end
 
-@Geth_Network_Id  = @config["geth"]["network"]["id"]
+@Geth_Network_Id  = 1101
+if @config["geth"] and @config["geth"]["network"] and @config["geth"]["network"]["id"]
+  @Geth_Network_Id = @config["geth"]["network"]["id"]
+end
 @Accounts = ""
 @Account_Allocs = ""
 @Node_Index = 0

--- a/templates/quorum/genesis.json.erb
+++ b/templates/quorum/genesis.json.erb
@@ -5,7 +5,6 @@ def set_node_template_vars(values)
     return
 end
 
-@Key_Dir_Base     = @config["quorum"]["Key_Dir_Base"]
 @Geth_Network_Id  = @config["geth"]["network"]["id"]
 @Accounts = ""
 @Account_Allocs = ""

--- a/templates/quorum/permissioned-nodes.json.erb
+++ b/templates/quorum/permissioned-nodes.json.erb
@@ -8,13 +8,12 @@ end
 <%- # The configured key directory of each node holds a file with the enode value.
    # The enode value is obtained from that file and set in the permissioned-nodes.json
 -%>
-<%- @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"]
-   @NodeP2P_ListenAddr = @config["geth"]["NodeP2P_ListenAddr"] -%>
+<%- @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"] -%>
 [
 <%- @nodes.each_with_index do |node, indexNode| -%>
     <%- set_node_template_vars(node.values.first) -%>
     <%- @Enode_File = @config["quorum"]["Key_Dir_Base"] + "/" + @Node_Key_Dir + "/enode" -%>
     <%- File.readlines(@Enode_File).each do |line| @Enode = "#{line}".gsub(/\s+/, "") end -%>
-  "enode://<%= @Enode %>@%<%= "#{@Node_UserIdent}".upcase %>_SERVICE_HOST%:<%= @NodeP2P_ListenAddr%>?discport=0&raftport=50401"<%- if (indexNode != @nodes.size - 1) %>,<%- end %>
+  "enode://<%= @Enode %>@%<%= "#{@Node_UserIdent}".upcase %>_SERVICE_HOST%:<%= @NodeP2P_ListenAddr%>?discport=0&raftport=<%= @Raft_Port%>"<%- if (indexNode != @nodes.size - 1) %>,<%- end %>
 <% end -%>
 ]

--- a/templates/quorum/permissioned-nodes.json.erb
+++ b/templates/quorum/permissioned-nodes.json.erb
@@ -8,11 +8,10 @@ end
 <%- # The configured key directory of each node holds a file with the enode value.
    # The enode value is obtained from that file and set in the permissioned-nodes.json
 -%>
-<%- @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"] -%>
 [
 <%- @nodes.each_with_index do |node, indexNode| -%>
     <%- set_node_template_vars(node.values.first) -%>
-    <%- @Enode_File = @config["quorum"]["Key_Dir_Base"] + "/" + @Node_Key_Dir + "/enode" -%>
+    <%- @Enode_File = @Key_Dir_Base + "/" + @Node_Key_Dir + "/enode" -%>
     <%- File.readlines(@Enode_File).each do |line| @Enode = "#{line}".gsub(/\s+/, "") end -%>
   "enode://<%= @Enode %>@%<%= "#{@Node_UserIdent}".upcase %>_SERVICE_HOST%:<%= @NodeP2P_ListenAddr%>?discport=0&raftport=<%= @Raft_Port%>"<%- if (indexNode != @nodes.size - 1) %>,<%- end %>
 <% end -%>

--- a/templates/quorum/tessera-config-9.0.json.erb
+++ b/templates/quorum/tessera-config-9.0.json.erb
@@ -10,7 +10,6 @@ end
 # for more information about the tessera-config file see https://github.com/jpmorganchase/tessera/wiki/Configuration-overview.
 %>
 <%
-   @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"]
    @DDIR         = @Node_DataDir + "/tm"
 %>
 {

--- a/templates/quorum/tessera-config-9.0.json.erb
+++ b/templates/quorum/tessera-config-9.0.json.erb
@@ -11,7 +11,6 @@ end
 %>
 <%
    @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"]
-   @Tm_Port      = @config["quorum"]["tm"]["Port"]
    @DDIR         = @Node_DataDir + "/tm"
 %>
 {

--- a/templates/quorum/tessera-config-enhanced.json.erb
+++ b/templates/quorum/tessera-config-enhanced.json.erb
@@ -10,7 +10,6 @@ end
 # for more information about the tessera-config file see https://github.com/jpmorganchase/tessera/wiki/Configuration-overview.
 %>
 <%
-   @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"]
    @DDIR         = @Node_DataDir + "/tm"
 %>
 {

--- a/templates/quorum/tessera-config-enhanced.json.erb
+++ b/templates/quorum/tessera-config-enhanced.json.erb
@@ -11,7 +11,6 @@ end
 %>
 <%
    @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"]
-   @Tm_Port      = @config["quorum"]["tm"]["Port"]
    @DDIR         = @Node_DataDir + "/tm"
 %>
 {

--- a/templates/quorum/tessera-config.json.erb
+++ b/templates/quorum/tessera-config.json.erb
@@ -10,8 +10,6 @@ end
 # for more information about the tessera-config file see https://github.com/jpmorganchase/tessera/wiki/Configuration-overview
 %>
 <%
-   @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"]
-   @Node_DataDir = @config["quorum"]["Node_DataDir"]
    @DDIR         = @Node_DataDir + "/tm"
 %>
 

--- a/templates/quorum/tessera-config.json.erb
+++ b/templates/quorum/tessera-config.json.erb
@@ -11,7 +11,6 @@ end
 %>
 <%
    @Key_Dir_Base = @config["quorum"]["Key_Dir_Base"]
-   @Tm_Port      = @config["quorum"]["tm"]["Port"]
    @Node_DataDir = @config["quorum"]["Node_DataDir"]
    @DDIR         = @Node_DataDir + "/tm"
 %>


### PR DESCRIPTION
The entries required by the base config have been reduced to: nodes.number, consensus, quorum version, and tessera version.  An example of the minimal config is added under `examples/config/qubes-minimal.yaml` and shown here: 

```
nodes:
  number: 4
quorum:
  # supported: (raft | istanbul)
  consensus: istanbul
  quorum:
    Quorum_Version: 2.2.5
  tm:
    # (tessera|constellation)
    Name: tessera
    Tm_Version: 0.11
```

All other values will receive reasonable defaults, e.g. geth ports will be the default geth ports. The default values are as follows: 
```
Raft_Port = 50401
Tm_Port = 9001
Node_RPCPort = 8545
geth p2p port = 30303
service.type =  "NodePort"
geth.verbosity = 9
geth.chainId = 1101
Tessera_Config_Dir = "out/config"   
Genesis_File = "out/config/genesis.json"
Permissioned_Nodes_File = "out/config/permissioned-nodes.json"
Key_Dir_Base = "out/config"
Node_DataDir = "/etc/quorum/qdata"
```
The default values will be overridden, If set in the config yaml used to generate the network.

