### PR TITLE
Refactor quorum-init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The `qubernetes.yaml` file and the desired `out` directory will need to be mount
 ```bash
 $> git clone https://github.com/jpmorganchase/qubernetes.git
 $> cd qubernetes
-qubernetes $> docker run --rm -it -v $(pwd)/qubernetes.yaml:/qubernetes/qubernetes.yaml -v $(pwd)/out:/qubernetes/out  quorumengineering/qubernetes ./quorum-init qubernetes.yaml
+qubernetes $> docker run --rm -it -v $(pwd)/qubernetes.yaml:/qubernetes/qubernetes.yaml -v $(pwd)/out:/qubernetes/out  quorumengineering/qubernetes ./qube-init qubernetes.yaml
 qubernetes $> ls out 
 ``` 
 [![docker-quberentes-boot-1](docs/resources/docker-quberentes-boot-1-play.png)](https://jpmorganchase.github.io/qubernetes/resources/docker-quberentes-boot-1.webm)
@@ -172,7 +172,7 @@ cool-qubernetes.yaml
 
 # run docker and mount cool-qubernetes.yaml and the out directory
 # a prompt will appear enter 1 to Delete the 'out' directory and generate new resources. 
-myDir$> docker run --rm -it -v $(pwd)/cool-qubernetes.yaml:/qubernetes/cool-qubernetes.yaml -v $(pwd)/out:/qubernetes/out quorumengineering/qubernetes ./quorum-init cool-qubernetes.yaml
+myDir$> docker run --rm -it -v $(pwd)/cool-qubernetes.yaml:/qubernetes/cool-qubernetes.yaml -v $(pwd)/out:/qubernetes/out quorumengineering/qubernetes ./qube-init cool-qubernetes.yaml
 using config file: cool-qubernetes.yaml
 
  The 'out' directory already exist.
@@ -200,7 +200,7 @@ so it is as if we were running on our local host: the files from the host will b
 $> git clone https://github.com/jpmorganchase/qubernetes.git
 $> cd qubernetes 
 qubernetes $> docker run --rm -it -v $(pwd):/qubernetes -ti quorumengineering/qubernetes
-root@4eb772b14086:/qubernetes# ./quorum-init
+root@4eb772b14086:/qubernetes# ./qube-init
 
 root@4eb772b14086:/qubernetes# ls out/
 00-quorum-persistent-volumes.yaml  01-quorum-genesis.yaml  02-quorum-shared-config.yaml  03-quorum-services.yaml  04-quorum-keyconfigs.yaml  config  deployments
@@ -218,7 +218,7 @@ nodes:
   number: 8
 ```
 
-2. Run `./quorum-init` to generate everything needed for the quorum deployment: quorum keys, genesis.json, istanbul-config.json, permissioned-nodes.json, etc. 
+2. Run `./qube-init` to generate everything needed for the quorum deployment: quorum keys, genesis.json, istanbul-config.json, permissioned-nodes.json, etc.
   
  These resources will be written and read from the directories specified in the `qubernetes.yaml` file.
  The default [`qubernetes.yaml`](qubernetes.yaml) is configured to write theses to the `./out/config` directory.
@@ -231,7 +231,7 @@ nodes:
  ```shell
  
  ## in this case, an out directory exists, so select `1`.
- $> ./quorum-init
+ $> ./qube-init
  The 'out' directory already exist.
  Please select the action you wish to take:
 

--- a/qube-init
+++ b/qube-init
@@ -48,7 +48,7 @@ end
 
 puts  "  Running ./quorum-init to generate Quorum resources."
 
-exec("./quorum-init --action=#{@ACTION_FLAG} #{@CONFIG_FILE}")
+system("./quorum-init --action=#{@ACTION_FLAG} #{@CONFIG_FILE}")
 
 
 puts  "  Running ./qubernetes to generate Kubernetes resources."

--- a/qube-init
+++ b/qube-init
@@ -11,12 +11,12 @@ OptionParser.new do |opts|
   opts.banner = "Usage: ./qube-init [options]"
 
   opts.on("-a", "--action [ACTION]", String,
-            "create: override out directory and generate new resources,
-                                     update: keep out directory and only add additional resources") do |a|
+            "create: override out directory and generate new resources.
+                                     update: keep out directory and only add additional resources.") do |a|
     options[:action] = a
   end
 
-  opts.on("-h", "--help", "Prints this help") do
+  opts.on("-h", "--help", "prints this help.") do
     puts opts
     exit
   end

--- a/qube-init
+++ b/qube-init
@@ -5,15 +5,15 @@ require "erb"
 require 'optparse'
 
 # set up flag options
-options = {command: 'ask'}
+options = {action: 'ask'}
 
 OptionParser.new do |opts|
-  opts.banner = "Usage: ./quorum-init [options]"
+  opts.banner = "Usage: ./qube-init [options]"
 
-  opts.on("-c", "--command [COMMAND]", String,
+  opts.on("-a", "--action [ACTION]", String,
             "create: override out directory and generate new resources,
-                                     update: keep out directory and only add additional resources") do |c|
-    options[:command] = c
+                                     update: keep out directory and only add additional resources") do |a|
+    options[:action] = a
   end
 
   opts.on("-h", "--help", "Prints this help") do
@@ -23,9 +23,9 @@ OptionParser.new do |opts|
 
 end.parse!
 
-@COMMAND_FLAG=options[:command]
+@ACTION_FLAG=options[:action]
 
-puts "using command flag : " + @COMMAND_FLAG
+puts "using action flag : " + @ACTION_FLAG
 
 # setup the config file to use to generate the quorum resources and kubernetes API resources.
 @CONFIG_FILE = "qubernetes.yaml"
@@ -47,9 +47,9 @@ end
 
 
 puts  "  Running ./quorum-init to generate Quorum resources."
-`
-./quorum-init --command=#{@COMMAND_FLAG} #{@CONFIG_FILE}
-`
+
+exec("./quorum-init --action=#{@ACTION_FLAG} #{@CONFIG_FILE}")
+
 
 puts  "  Running ./qubernetes to generate Kubernetes resources."
 puts ""

--- a/qube-init
+++ b/qube-init
@@ -2,6 +2,30 @@
 
 require "yaml"
 require "erb"
+require 'optparse'
+
+# set up flag options
+options = {command: 'ask'}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: ./quorum-init [options]"
+
+  opts.on("-c", "--command [COMMAND]", String,
+            "create: override out directory and generate new resources,
+                                     update: keep out directory and only add additional resources") do |c|
+    options[:command] = c
+  end
+
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+
+end.parse!
+
+@COMMAND_FLAG=options[:command]
+
+puts "using command flag : " + @COMMAND_FLAG
 
 # setup the config file to use to generate the quorum resources and kubernetes API resources.
 @CONFIG_FILE = "qubernetes.yaml"
@@ -21,8 +45,10 @@ if @config["sep_deployment_files"] != nil
   @sep_deployment_files = @config["sep_deployment_files"]
 end
 
+
+puts  "  Running ./quorum-init to generate Quorum resources."
 `
-./quorum-init #{@CONFIG_FILE}
+./quorum-init --command=#{@COMMAND_FLAG} #{@CONFIG_FILE}
 `
 
 puts  "  Running ./qubernetes to generate Kubernetes resources."

--- a/qube-init
+++ b/qube-init
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+require "erb"
+
+# setup the config file to use to generate the quorum resources and kubernetes API resources.
+@CONFIG_FILE = "qubernetes.yaml"
+@OPTIONAL_CONFIG_FILE=ARGV[0]
+ARGV.clear
+
+if @OPTIONAL_CONFIG_FILE != nil
+  @CONFIG_FILE = @OPTIONAL_CONFIG_FILE
+end
+puts "using config file: " + @CONFIG_FILE
+
+@config                = YAML.load_file(@CONFIG_FILE)
+
+# Generate deployments in a single file, or in separate files.
+@sep_deployment_files=false
+if @config["sep_deployment_files"] != nil
+  @sep_deployment_files = @config["sep_deployment_files"]
+end
+
+`
+./quorum-init #{@CONFIG_FILE}
+`
+
+puts  "  Running ./qubernetes to generate Kubernetes resources."
+puts ""
+`
+./qubernetes #{@CONFIG_FILE}
+`
+@Kubectl_Cmd="  $> kubectl apply -f out"
+if @sep_deployment_files
+  @Kubectl_Cmd="  $> kubectl apply -f out -f out/deployments"
+end
+puts("  To deploy to kubernetes run:")
+puts(@Kubectl_Cmd)

--- a/quickest-start.sh
+++ b/quickest-start.sh
@@ -124,8 +124,8 @@ echo "kind cluster created"
 if [[ $NUM_NODES -gt 0 ]];
 then
   cat qubernetes.yaml | sed "s/number:.*/number: $NUM_NODES/g" > quickest-start.yaml
-  echo docker run --rm -it -v $(pwd):/qubernetes quorumengineering/qubernetes ./quorum-init quickest-start.yaml
-  docker run --rm -it -v $(pwd):/qubernetes quorumengineering/qubernetes ./quorum-init quickest-start.yaml
+  echo docker run --rm -it -v $(pwd):/qubernetes quorumengineering/qubernetes ./qube-init quickest-start.yaml
+  docker run --rm -it -v $(pwd):/qubernetes quorumengineering/qubernetes ./qube-init quickest-start.yaml
   kubectl apply -f out -f out/deployments > /dev/null
 else
   echo "Deploying 7nodes with Privacy manager tessera and consensus IBFT"

--- a/quorum-init
+++ b/quorum-init
@@ -11,12 +11,12 @@ OptionParser.new do |opts|
   opts.banner = "Usage: ./quorum-init [options]"
 
   opts.on("-a", "--action [ACTION]", String,
-            "create: override out directory and generate new resources,
-                                     update: keep out directory and only add additional resources") do |a|
+            "create: override out directory and generate new resources.
+                                     update: keep out directory and only add additional resources.") do |a|
     options[:action] = a
   end
 
-  opts.on("-h", "--help", "Prints this help") do
+  opts.on("-h", "--help", "prints this help.") do
     puts opts
     exit
   end

--- a/quorum-init
+++ b/quorum-init
@@ -5,15 +5,15 @@ require "erb"
 require 'optparse'
 
 # set up flag options
-options = {command: 'ask'}
+options = {action: 'ask'}
 
 OptionParser.new do |opts|
   opts.banner = "Usage: ./quorum-init [options]"
 
-  opts.on("-c", "--command [COMMAND]", String,
+  opts.on("-a", "--action [ACTION]", String,
             "create: override out directory and generate new resources,
-                                     update: keep out directory and only add additional resources") do |c|
-    options[:command] = c
+                                     update: keep out directory and only add additional resources") do |a|
+    options[:action] = a
   end
 
   opts.on("-h", "--help", "Prints this help") do
@@ -36,16 +36,13 @@ puts "using config file: " + @CONFIG_FILE
 @config                = YAML.load_file(@CONFIG_FILE)
 
 # decide to create new resources
-command = options[:command]
+action = options[:action]
 createNew=false
-if (command == 'create')
+if (action == 'create')
     createNew=true
 end
 
-p command
-p createNew
-
-if File.directory?("out") && (command == 'ask')
+if File.directory?("out") && (action == 'ask')
   puts("\n The 'out' directory already exist.")
   puts(" Please select the action you wish to take:")
   puts("")

--- a/quorum-init
+++ b/quorum-init
@@ -14,13 +14,8 @@ end
 puts "using config file: " + @CONFIG_FILE
 
 @config                = YAML.load_file(@CONFIG_FILE)
-# Generate deployments in a single file, or in separate files.
-@sep_deployment_files=false
-if @config["sep_deployment_files"] != nil
-  @sep_deployment_files = @config["sep_deployment_files"]
-end
 
-if File.directory?("out")
+if File.directory?("out") && !@config["skip_out_directory"]
   puts("\n The 'out' directory already exist.")
   puts(" Please select the action you wish to take:")
   puts("")
@@ -48,12 +43,10 @@ end
 # create the output directory if
 # it doesn't exist
 mkdir -p out/config
-
 # generate the nodes.yaml
 # file for the set number of
 # nodes.
 ./quorum-create-nodes #{@CONFIG_FILE}
-
 `
 puts ""
 puts "  Generating keys..."
@@ -74,15 +67,3 @@ puts "  Generating Quorum configs..."
 
 puts ""
 puts  "  Base quorum resources have been generated. "
-puts  "  Running ./qubernetes to generate Kubernetes resources."
-puts ""
-`
-./qubernetes #{@CONFIG_FILE}
-`
-@Kubectl_Cmd="  $> kubectl apply -f out"
-if @sep_deployment_files
-  @Kubectl_Cmd="  $> kubectl apply -f out -f out/deployments"
-end
-puts("  To deploy to kubernetes run:")
-puts(@Kubectl_Cmd)
-

--- a/quorum-init
+++ b/quorum-init
@@ -2,6 +2,26 @@
 
 require "yaml"
 require "erb"
+require 'optparse'
+
+# set up flag options
+options = {command: 'ask'}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: ./quorum-init [options]"
+
+  opts.on("-c", "--command [COMMAND]", String,
+            "create: override out directory and generate new resources,
+                                     update: keep out directory and only add additional resources") do |c|
+    options[:command] = c
+  end
+
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+
+end.parse!
 
 # setup the config file to use to generate the quorum resources and kubernetes API resources.
 @CONFIG_FILE = "qubernetes.yaml"
@@ -15,7 +35,17 @@ puts "using config file: " + @CONFIG_FILE
 
 @config                = YAML.load_file(@CONFIG_FILE)
 
-if File.directory?("out") && !@config["skip_out_directory"]
+# decide to create new resources
+command = options[:command]
+createNew=false
+if (command == 'create')
+    createNew=true
+end
+
+p command
+p createNew
+
+if File.directory?("out") && (command == 'ask')
   puts("\n The 'out' directory already exist.")
   puts(" Please select the action you wish to take:")
   puts("")
@@ -27,7 +57,7 @@ if File.directory?("out") && !@config["skip_out_directory"]
   case res
   when "1"
     puts("Creating all new resources.")
-    `rm -r out`
+    createNew=true
   when "2"
     puts("Generating additional resources only.")
   when "3"
@@ -37,6 +67,11 @@ if File.directory?("out") && !@config["skip_out_directory"]
     puts("OK, not doing anything :)")
     exit(0)
   end
+end
+
+# delete out directory if creating new
+if createNew
+    `rm -r out`
 end
 
 `

--- a/testing/gen-configs.sh
+++ b/testing/gen-configs.sh
@@ -36,7 +36,7 @@ for CONFIG_FILE in $CONFIG_DIR*;
 do
  echo "Config file: ${CONFIG_FILE}"
  NAMESPACE=$(echo $CONFIG_FILE | sed 's/.yaml//g' | sed "s|$CONFIG_DIR||g")
- ./quorum-init ${CONFIG_FILE} &&
+ ./qube-init ${CONFIG_FILE} &&
  rm -rf $OUT_DIR/$NAMESPACE
  mv out $OUT_DIR/$NAMESPACE
 done


### PR DESCRIPTION
separates quorum-init into 2 scripts...
-quorum-init only generates resources needed for quorum
-qube-init calls quorum-init and generates kubernetes resources
updates calls to quorum-init in readme/tests
adds action flag (--action create|update, --action=create|update, -acreate|update) to skip user prompt of asking about out directory, not having flag will run prompt if out directory exists

example of how to run with flags:
./quorum-init --action=create qubernetes.yaml
./quorum-init --action=update qubernetes.yaml
./qube-init --action=create qubernetes.yaml
./qube-init --action=update qubernetes.yaml