### PR TITLE
enable cors on tessera 3rd party

### DIFF
--- a/examples/config/qubernetes-custom-docker-repo.yaml
+++ b/examples/config/qubernetes-custom-docker-repo.yaml
@@ -31,6 +31,7 @@ quorum:
     # the docker repo that hold your quorum container
     Docker_Repo: %%YOUR_CUSTOM_DOCKER_REPO%%
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   # test locally and on GCP

--- a/examples/config/qubernetes-ingress.yaml
+++ b/examples/config/qubernetes-ingress.yaml
@@ -32,8 +32,9 @@ quorum:
     # (tessera|constellation)
     Name: tessera
     #Tm_Version: 0.9.2
-    Tm_Version: 0.10.0
+    Tm_Version: 0.10.2
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   # test locally and on GCP

--- a/examples/config/qubernetes-istanbul-7nodes.yaml
+++ b/examples/config/qubernetes-istanbul-7nodes.yaml
@@ -28,6 +28,7 @@ quorum:
     # container images at https://hub.docker.com/u/quorumengineering/
     #       in that case.
     Tm_Version: 0.3.2
+    3Party_Port: 9080
     Port: 9001
 # generic geth related options
 geth:

--- a/examples/config/qubernetes-istanbul-generate-8nodes.yaml
+++ b/examples/config/qubernetes-istanbul-generate-8nodes.yaml
@@ -26,8 +26,9 @@ quorum:
     # container images at https://hub.docker.com/u/quorumengineering/
     # (tessera|constellation)
     Name: tessera
-    Tm_Version: 0.9.2
+    Tm_Version: 0.10.2
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   # test locally and on GCP

--- a/examples/config/qubernetes-network-policy.yaml
+++ b/examples/config/qubernetes-network-policy.yaml
@@ -34,6 +34,7 @@ quorum:
     Name: tessera
     Tm_Version: 0.10.2
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   # test locally and on GCP

--- a/examples/config/qubernetes-pvc-annotations.yaml
+++ b/examples/config/qubernetes-pvc-annotations.yaml
@@ -29,6 +29,7 @@ quorum:
     Name: tessera
     Tm_Version: 0.10.2
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   storage:

--- a/examples/config/qubernetes-pvc-storageclass.yaml
+++ b/examples/config/qubernetes-pvc-storageclass.yaml
@@ -29,6 +29,7 @@ quorum:
     Name: tessera
     Tm_Version: 0.10.2
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   storage:

--- a/examples/config/qubernetes-raft-generate-8nodes.yaml
+++ b/examples/config/qubernetes-raft-generate-8nodes.yaml
@@ -28,6 +28,7 @@ quorum:
     Name: tessera 
     Tm_Version: 0.9.2
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
 # generic geth related options
 geth:

--- a/examples/config/qubernetes-security-context.yaml
+++ b/examples/config/qubernetes-security-context.yaml
@@ -33,6 +33,7 @@ quorum:
     Name: tessera
     Tm_Version: 0.11
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   # test locally and on GCP

--- a/qubernetes
+++ b/qubernetes
@@ -78,7 +78,7 @@ end
 
 @NodeP2P_ListenAddr = 30303
 if @config["geth"] and @config["geth"]["NodeP2P_ListenAddr"]
-  @NodeP2P_ListenAdd = @config["geth"]["NodeP2P_ListenAddr"]
+  @NodeP2P_ListenAddr = @config["geth"]["NodeP2P_ListenAddr"]
 end
 
 

--- a/qubernetes
+++ b/qubernetes
@@ -61,6 +61,11 @@ if @config["quorum"]["tm"]["Port"]
   @Tm_Port = @config["quorum"]["tm"]["Port"]
 end
 
+@Tm_3Party_Port = 9080
+if @config["quorum"]["tm"]["3Party_Port"]
+  @Tm_3Party_Port = @config["quorum"]["tm"]["3Party_Port"]
+end
+
 @Node_RPCPort = 8545
 if @config["geth"] and @config["geth"]["Node_RPCPort"]
   @Node_RPCPort = @config["geth"]["Node_RPCPort"]

--- a/qubernetes.yaml
+++ b/qubernetes.yaml
@@ -30,6 +30,7 @@ quorum:
     #Tm_Version: 0.9.2
     Tm_Version: 0.10.2
     Port: 9001
+    3Party_Port: 9080
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   # test locally and on GCP

--- a/qubernetes.yaml
+++ b/qubernetes.yaml
@@ -28,7 +28,7 @@ quorum:
     # (tessera|constellation)
     Name: tessera
     #Tm_Version: 0.9.2
-    Tm_Version: 0.10.0
+    Tm_Version: 0.10.2
     Port: 9001
     Tessera_Config_Dir: out/config
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/

--- a/quorum-config
+++ b/quorum-config
@@ -54,6 +54,11 @@ end
 if @config["quorum"]["tm"]["Port"]
   @Tm_Port = @config["quorum"]["tm"]["Port"]
 end
+# Tm_3Party_Port used in tessera config templates
+@Tm_3Party_Port = 9080
+if @config["quorum"]["tm"]["3Party_Port"]
+  @Tm_3Party_Port = @config["quorum"]["tm"]["3Party_Port"]
+end
 # used by permissioned-nodes.json.erb to set enode URLs
 @Raft_Port = 50401
 if @config["quorum"]["quorum"]["Raft_Port"]

--- a/quorum-config
+++ b/quorum-config
@@ -66,7 +66,7 @@ if @config["quorum"]["quorum"]["Raft_Port"]
 end
 @NodeP2P_ListenAddr = 30303
 if @config["geth"] and @config["geth"]["NodeP2P_ListenAddr"]
-  @NodeP2P_ListenAdd = @config["geth"]["NodeP2P_ListenAddr"]
+  @NodeP2P_ListenAddr = @config["geth"]["NodeP2P_ListenAddr"]
 end
 
 #####################################################

--- a/templates/k8s/network-policy.yaml.erb
+++ b/templates/k8s/network-policy.yaml.erb
@@ -55,6 +55,6 @@ spec:
               app: qubernetes
       ports:
         - port: <%= @TM_Port %>
-        - port: <%= @Node_RPCPort %>
+        - port: <%= @Tm_3Party_Port %>
         - port: <%= @Node_RPCPort %>
         - port: <%= @Node_WSPort %>

--- a/templates/k8s/network-policy.yaml.erb
+++ b/templates/k8s/network-policy.yaml.erb
@@ -16,7 +16,7 @@ spec:
           matchLabels:
             app: qubernetes
       ports:
-        -  port: <%= @TM_Port %>
+        -  port: <%= @Tm_Port %>
         -  port: <%= @Tm_3Party_Port %>
         -  port: <%= @Raft_Port %>
         -  port: <%= @Node_RPCPort %>
@@ -27,8 +27,8 @@ spec:
           matchLabels:
             app: qubernetes
       ports:
-        - port: <%= @TM_Port %>
-        - port: <%= @TM_3Party_Port %>
+        - port: <%= @Tm_Port %>
+        - port: <%= @Tm_3Party_Port %>
         - port: <%= @Raft_Port %>
         - port: <%= @Node_RPCPort %>
         - port: <%= @NodeP2P_ListenAddr %>
@@ -52,6 +52,6 @@ spec:
             matchLabels:
               app: qubernetes
       ports:
-        - port: <%= @TM_Port %>
+        - port: <%= @Tm_Port %>
         - port: <%= @Tm_3Party_Port %>
-        - port:  <%= @Node_RPCPort %>
+        - port: <%= @Node_RPCPort %>

--- a/templates/k8s/network-policy.yaml.erb
+++ b/templates/k8s/network-policy.yaml.erb
@@ -17,7 +17,7 @@ spec:
             app: qubernetes
       ports:
         -  port: <%= @TM_Port %>
-        -  port: 9080
+        -  port: <%= @Tm_3Party_Port %>
         -  port: <%= @Raft_Port %>
         -  port: <%= @Node_RPCPort %>
         -  port: <%= @NodeP2P_ListenAddr %>
@@ -28,7 +28,7 @@ spec:
             app: qubernetes
       ports:
         - port: <%= @TM_Port %>
-        - port: 9080
+        - port: <%= @TM_3Party_Port %>
         - port: <%= @Raft_Port %>
         - port: <%= @Node_RPCPort %>
         - port: <%= @NodeP2P_ListenAddr %>
@@ -53,5 +53,5 @@ spec:
               app: qubernetes
       ports:
         - port: <%= @TM_Port %>
-        - port: 9080
+        - port: <%= @Tm_3Party_Port %>
         - port:  <%= @Node_RPCPort %>

--- a/templates/k8s/quorum-ingress.yaml.erb
+++ b/templates/k8s/quorum-ingress.yaml.erb
@@ -84,7 +84,7 @@ spec:
             backend:
               serviceName: <%= @Node_UserIdent %>
               servicePort: <%= @Node_RPCPort %>
-          - path: /tessera-3Party
+          - path: /<%= @Node_UserIdent %>/tessera-3Party
             backend:
               serviceName: <%= @Node_UserIdent %>
               servicePort: <%= @Tm_3Party_Port %>

--- a/templates/k8s/quorum-ingress.yaml.erb
+++ b/templates/k8s/quorum-ingress.yaml.erb
@@ -36,6 +36,10 @@ spec:
             backend:
               serviceName: <%= @Node_UserIdent %>
               servicePort: <%= @Node_RPCPort %>
+          - path: /tessera-3Party
+            backend:
+              serviceName: <%= @Node_UserIdent %>
+              servicePort: <%= @Tm_3Party_Port %>
   tls:
     - hosts:
         - "<%= @Node_UserIdent %>.<%= @Ingress_Host %>"
@@ -46,6 +50,10 @@ spec:
             backend:
               serviceName: <%= @Node_UserIdent %>
               servicePort: <%= @Node_RPCPort %>
+          - path: /tessera-3Party
+            backend:
+              serviceName: <%= @Node_UserIdent %>
+              servicePort: <%= @Tm_3Party_Port %>
           <%- end -%> <%# End Host conditional %>
      <% end -%> <%# end this node iteration %>
 <%- end -%> <%# End Ingress OneForEach (this node's ingress) %>
@@ -76,6 +84,10 @@ spec:
             backend:
               serviceName: <%= @Node_UserIdent %>
               servicePort: <%= @Node_RPCPort %>
+          - path: /tessera-3Party
+            backend:
+              serviceName: <%= @Node_UserIdent %>
+              servicePort: <%= @Tm_3Party_Port %>
           <%- end -%> <%# end setting path for each node %>
 <%- if @Ingress_Host -%>
   tls:

--- a/templates/k8s/quorum-ingress.yaml.erb
+++ b/templates/k8s/quorum-ingress.yaml.erb
@@ -40,10 +40,6 @@ spec:
             backend:
               serviceName: <%= @Node_UserIdent %>
               servicePort: <%= @Node_WSPort %>
-          - path: /tessera-3Party
-            backend:
-              serviceName: <%= @Node_UserIdent %>
-              servicePort: <%= @Tm_3Party_Port %>
   tls:
     - hosts:
         - "<%= @Node_UserIdent %>.<%= @Ingress_Host %>"
@@ -58,10 +54,6 @@ spec:
             backend:
               serviceName: <%= @Node_UserIdent %>
               servicePort: <%= @Node_WSPort %>
-          - path: /tessera-3Party
-            backend:
-              serviceName: <%= @Node_UserIdent %>
-              servicePort: <%= @Tm_3Party_Port %>
           <%- end -%> <%# End Host conditional %>
      <% end -%> <%# end this node iteration %>
 <%- end -%> <%# End Ingress OneForEach (this node's ingress) %>
@@ -96,10 +88,6 @@ spec:
             backend:
               serviceName: <%= @Node_UserIdent %>
               servicePort: <%= @Node_WSPort %>
-          - path: /<%= @Node_UserIdent %>/tessera-3Party
-            backend:
-              serviceName: <%= @Node_UserIdent %>
-              servicePort: <%= @Tm_3Party_Port %>
           <%- end -%> <%# end setting path for each node %>
 <%- if @Ingress_Host -%>
   tls:

--- a/templates/k8s/quorum-services.yaml.erb
+++ b/templates/k8s/quorum-services.yaml.erb
@@ -40,8 +40,8 @@ spec:
     # default 8545
     - name: tm-tessera-third-part
       protocol: TCP
-      port: 9080
-      targetPort: 9080
+      port: <%= @Tm_3Party_Port %>
+      targetPort: <%= @Tm_3Party_Port %>
     # default 8545
     - name: rpc-listener
       protocol: TCP

--- a/templates/quorum/tessera-config-9.0.json.erb
+++ b/templates/quorum/tessera-config-9.0.json.erb
@@ -25,6 +25,15 @@ end
     "app":"ThirdParty",
     "enabled": true,
     "serverAddress": "http://%THIS_SERVICE_HOST%:9080",
+    "cors": {
+        "allowedMethods": [
+            "GET",
+            "OPTIONS"
+        ],
+        "allowedOrigins": [
+            "*"
+        ]
+    },
     "communicationType" : "REST"
   },
   {

--- a/templates/quorum/tessera-config-9.0.json.erb
+++ b/templates/quorum/tessera-config-9.0.json.erb
@@ -24,7 +24,7 @@ end
   {
     "app":"ThirdParty",
     "enabled": true,
-    "serverAddress": "http://%THIS_SERVICE_HOST%:9080",
+    "serverAddress": "http://%THIS_SERVICE_HOST%:<%= @Tm_3Party_Port %>",
     "cors": {
         "allowedMethods": [
             "GET",

--- a/templates/quorum/tessera-config-enhanced.json.erb
+++ b/templates/quorum/tessera-config-enhanced.json.erb
@@ -26,7 +26,7 @@ end
     "enabled": true,
     "serverSocket":{
       "type":"INET",
-      "port": 9080,
+      "port": <%= @Tm_3Party_Port %>,
       "hostName": "http://%THIS_SERVICE_HOST%"
     },
     "communicationType" : "REST"


### PR DESCRIPTION
adds cors to tessera config for 3rd party port
allows remix to connect to tessera for private key info
makes tessera 3rd party port configurable
fixes quorum p2p typos