### PR TITLE
Minor fixes for adding (raft/ibft) nodes.

### DIFF
--- a/helpers/add_nodes_to_k8s.sh
+++ b/helpers/add_nodes_to_k8s.sh
@@ -12,11 +12,15 @@ GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
 ## apply the new  configs from the out dir
-## make sure the genesis didn't change.
-kubectl apply -f out/00-quorum-persistent-volumes.yaml
-kubectl apply -f out/02-quorum-shared-config.yaml
-kubectl apply -f out/03-quorum-services.yaml
-kubectl apply -f out/04-quorum-keyconfigs.yaml
+## but don't update the genesis file / config.
+for f in out/*
+do
+	if [[ "$f" == *"genesis"* ]]; then
+	   echo "skip reapplying genesis config"
+  else
+	   kubectl apply -f $f
+	fi
+done
 echo
 kubectl get pods
 

--- a/helpers/ibft_add_nodes_to_k8s.sh
+++ b/helpers/ibft_add_nodes_to_k8s.sh
@@ -11,11 +11,16 @@ GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
 ## apply the new  configs from the out dir
-## make sure the genesis didn't change.
-kubectl apply -f out/00-quorum-persistent-volumes.yaml
-kubectl apply -f out/02-quorum-shared-config.yaml
-kubectl apply -f out/03-quorum-services.yaml
-kubectl apply -f out/04-quorum-keyconfigs.yaml
+## but don't update the genesis file / config.
+for f in out/*
+do
+	if [[ "$f" == *"genesis"* ]]; then
+	   echo "skip reapplying genesis config"
+  else
+	   kubectl apply -f $f
+	fi
+done
+
 echo
 kubectl get pods
 

--- a/helpers/raft_add_existing_update.sh
+++ b/helpers/raft_add_existing_update.sh
@@ -3,7 +3,7 @@
 #echo "enode://c57f7113aa5b05392d1e33c0dee1795f3d5855fb84c442f27488bd64be2b8571ae7b131737ba50b8e6946de2dda0e60c380cdc270c750d7e88e9582e70274be7@10.11.242.133:30303?discport=0&raftport=50401" | awk -F {Print $1}
 POD=$1
 #POD=quorum-node1-deployment-785b45b775-xl9rs
-RAFT_ID_ENODE_URL_CSV=$(kubectl exec -it $POD -c quorum cat /etc/quorum/qdata/contracts/raft_added.csv)
+RAFT_ID_ENODE_URL_CSV=$(kubectl exec -it $POD -c quorum -- cat /etc/quorum/qdata/contracts/raft_added.csv)
 
 mkdir -p out/deployments/updates
 


### PR DESCRIPTION
* when running `add_nodes_to_k8s.sh` or `ibft_add_nodes_to_k8s.sh` add all the updated config
files execpt the genesis config.

* `kubectl exec [POD]` --> `kubectl exec [POD] --` as the previous syntax is deprecated