### PR TITLE
Add tests for supported versions of quorum.

### DIFF
--- a/testing/qversions-config/qubes-ibft-2.2.0.yaml
+++ b/testing/qversions-config/qubes-ibft-2.2.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  quorum:
+    Quorum_Version: 2.2.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-ibft-2.3.0.yaml
+++ b/testing/qversions-config/qubes-ibft-2.3.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  quorum:
+    Quorum_Version: 2.3.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-ibft-2.4.0.yaml
+++ b/testing/qversions-config/qubes-ibft-2.4.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  quorum:
+    Quorum_Version: 2.4.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-ibft-2.5.0.yaml
+++ b/testing/qversions-config/qubes-ibft-2.5.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  quorum:
+    Quorum_Version: 2.5.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-ibft-2.6.0.yaml
+++ b/testing/qversions-config/qubes-ibft-2.6.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: istanbul
+  quorum:
+    Quorum_Version: 2.6.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-raft-2.2.0.yaml
+++ b/testing/qversions-config/qubes-raft-2.2.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: raft
+  quorum:
+    Quorum_Version: 2.2.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-raft-2.3.0.yaml
+++ b/testing/qversions-config/qubes-raft-2.3.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: raft
+  quorum:
+    Quorum_Version: 2.3.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-raft-2.4.0.yaml
+++ b/testing/qversions-config/qubes-raft-2.4.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: raft
+  quorum:
+    Quorum_Version: 2.4.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-raft-2.5.0.yaml
+++ b/testing/qversions-config/qubes-raft-2.5.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: raft
+  quorum:
+    Quorum_Version: 2.5.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/qversions-config/qubes-raft-2.6.0.yaml
+++ b/testing/qversions-config/qubes-raft-2.6.0.yaml
@@ -1,0 +1,23 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+sep_deployment_files: true
+# number of nodes to deploy
+nodes:
+  number: 3
+quorum:
+  # supported: (raft | istanbul)
+  consensus: raft
+  quorum:
+    Quorum_Version: 2.6.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.2
+geth:
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\"

--- a/testing/test-k8s-resources.sh
+++ b/testing/test-k8s-resources.sh
@@ -68,6 +68,7 @@ printf "${GREEN} Testing ${TOTAL_TEST_NUM} test networks. ${NC}\n"
 CT=0
 SUCCESS=0
 FAILURES=0
+FAILED_RUNS=""
 for OUT_DIR in $OUT_DIR_BASE/*;
 do
   ((CT=CT+1))
@@ -76,9 +77,13 @@ do
   printf "${RED}Total Failed networks: ${FAILURES}${NC}\n"
   # remove $OUT_DIR_BASE from the string to create the namespace
   echo $OUT_DIR | sed "s|$OUT_DIR_BASE||g" | sed 's|/||g'
-  NAMESPACE=$(echo $OUT_DIR | sed "s|$OUT_DIR_BASE||g" | sed 's|/||g')
-  echo $NAMESPACE
-  CUR_OUT_DIR=${OUT_DIR_BASE}/$NAMESPACE
+
+  CUR_OUT_DIR=$(echo $OUT_DIR | sed "s|$OUT_DIR_BASE||g" | sed 's|/||g')
+  CUR_OUT_DIR=${OUT_DIR_BASE}/$CUR_OUT_DIR
+  NAMESPACE=$(echo $OUT_DIR | sed "s|$OUT_DIR_BASE||g" | sed 's|/||g' | sed "s|\.|-|g")
+
+  echo "NAMESPACE: $NAMESPACE"
+  echo "CUR_OUT_DIR: $CUR_OUT_DIR"
 
   # Create namespace for this run
   kubectl delete namespace $NAMESPACE
@@ -132,6 +137,7 @@ do
  if [[ $EXIT_CODE -ne 0 ]];
  then
    ((FAILURES=FAILURES+1))
+   FAILED_RUNS="FAILED_RUNS, $CUR_OUT_DIR"
  else
    ((SUCCESS=SUCCESS+1))
  fi
@@ -147,7 +153,7 @@ done
 
 printf "${GREEN}Total Successful networks: ${SUCCESS}${NC}\n"
 printf "${RED}Total Failed networks: ${FAILURES}${NC}\n"
-
+printf "${RED}Failed runds: ${FAILED_RUNS}${NC}\n"
 if [[ $FAILURES -ne 0 ]]; then
   exit 1
 fi

--- a/testing/test-qnet.sh
+++ b/testing/test-qnet.sh
@@ -111,7 +111,7 @@ done
 # BLOCK_NUM will only instantly go up if raft
 # If istanbul it may take 5-10 seconds to start minting.
 ISTANBUL=$(echo $NAMESPACE | grep -i istan)
-
+ISTANBUL=$ISTANBUL$(echo $NAMESPACE | grep -i ibft)
 ## TODO: loop here, sometimes it takes a minute!
 # Istanbul has a condition where it may show block 1 for a while, then jump to a higher number, so if the consesus
 # is istanbul loop through until the block starts to increments to 2.
@@ -172,17 +172,13 @@ fi
 # try and wait for the private contract to execute without an error, e.g. in the case where
 # it hasn't started up completely.
 EXIT_CODE=1
-MAX_TRIES=10
+MAX_TRIES=20
 CT=0
 # if tessera may take longer, and will not throw an error exit code
 # err creating contract Error Non-200 status code: &{Status:404 Not Found StatusCode:404 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1
-while [[ $EXIT_CODE -ne 0 ]];
+while [[ "$CT" -lt "$MAX_TRIES" ]];
 do
   ((CT=CT+1))
-  if [[ "$CT" -ge "$MAX_TRIES" ]];
-  then
-    break
-  fi
   printf "${GREEN}Testing private transactions: attempt $CT out of $MAX_TRIES${NC}\n"
   echo helpers/run_contracts.sh $NODE_TO_TEST priv $NAMESPACE_NAME
   helpers/run_contracts.sh $NODE_TO_TEST priv $NAMESPACE_NAME
@@ -192,6 +188,9 @@ do
   get_block_number $NAMESPACE
   BLOCK_NUM=$?
   echo "BLOCK_NUM: [$BLOCK_NUM]"
+  if [[ $EXIT_CODE -eq 0 ]]; then
+    break;
+  fi
 done
 
 if [[ $EXIT_CODE -ne 0 ]];


### PR DESCRIPTION
* add config for all supported version of quorum to run `./test.sh qversions`.
* minor fixes / augmentations for test scripts, e.g. support '.' in file names of configs for testing.