### PR TITLE
 Reorg config to separate quorum config from k8s.

### DIFF
--- a/7nodes/istanbul-7nodes-constellation/qubernetes-istanbul-constellation-7nodes-pvc.yaml
+++ b/7nodes/istanbul-7nodes-constellation/qubernetes-istanbul-constellation-7nodes-pvc.yaml
@@ -3,12 +3,7 @@
 # number of nodes to deploy
 nodes:
   number: 7
-service:
-  # NodePort | ClusterIP
-  type: ClusterIP
 quorum:
-  # supported: raft | istanbul
-  consensus: istanbul
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -18,6 +13,8 @@ quorum:
   Genesis_File: 7nodes/istanbul-genesis.json
   # related to quorum containers
   quorum:
+    # supported: raft | istanbul
+    consensus: istanbul
     Raft_Port: 50401
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.5.0
@@ -29,13 +26,6 @@ quorum:
     Tm_Version: 0.3.2
     Port: 9001
     Tessera_Config_Dir: 7nodes
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 200Mi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -47,3 +37,14 @@ geth:
     public: false
   # general verbosity of geth [1..5]
   verbosity: 9
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: ClusterIP
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP.
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 200M

--- a/7nodes/istanbul-7nodes-constellation/qubernetes-istanbul-constellation-7nodes-pvc.yaml
+++ b/7nodes/istanbul-7nodes-constellation/qubernetes-istanbul-constellation-7nodes-pvc.yaml
@@ -1,5 +1,3 @@
-#namespace:
-#  name: quorum-test
 # number of nodes to deploy
 nodes:
   number: 7

--- a/7nodes/istanbul-7nodes-tessera/qubernetes-istanbul-tessera-7nodes-pvc.yaml
+++ b/7nodes/istanbul-7nodes-tessera/qubernetes-istanbul-tessera-7nodes-pvc.yaml
@@ -1,5 +1,3 @@
-#namespace:
-#  name: quorum-test
 # number of nodes to deploy
 nodes:
   number: 7

--- a/7nodes/istanbul-7nodes-tessera/qubernetes-istanbul-tessera-7nodes-pvc.yaml
+++ b/7nodes/istanbul-7nodes-tessera/qubernetes-istanbul-tessera-7nodes-pvc.yaml
@@ -3,12 +3,7 @@
 # number of nodes to deploy
 nodes:
   number: 7
-service:
-  # NodePort | ClusterIP
-  type: ClusterIP
 quorum:
-  # supported: raft | istanbul
-  consensus: istanbul
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -18,7 +13,8 @@ quorum:
   Genesis_File: 7nodes/istanbul-genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: raft | istanbul
+    consensus: istanbul
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.5.0
   # related to transaction manager containers
@@ -26,16 +22,9 @@ quorum:
     # (tessera|constellation)
     # container images at https://hub.docker.com/u/quorumengineering/
     Name: tessera
-    Tm_Version: 0.11
+    Tm_Version: 0.10.4
     Port: 9001
     Tessera_Config_Dir: 7nodes
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP.
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 200Mi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -47,3 +36,14 @@ geth:
     public: false
   # general verbosity of geth [1..5]
   verbosity: 9
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: ClusterIP
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP.
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 200Mi

--- a/7nodes/raft-7nodes-constellation/qubernetes-raft-constellation-7nodes-pvc.yaml
+++ b/7nodes/raft-7nodes-constellation/qubernetes-raft-constellation-7nodes-pvc.yaml
@@ -3,12 +3,7 @@
 # number of nodes to deploy
 nodes:
   number: 7
-service:
-  # NodePort | ClusterIP
-  type: ClusterIP
 quorum:
-  # supported: raft | istanbul
-  consensus: raft
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -18,7 +13,8 @@ quorum:
   Genesis_File: 7nodes/raft-genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: raft | istanbul
+    consensus: raft
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.5.0
   # related to transaction manager containers
@@ -29,13 +25,6 @@ quorum:
     Tm_Version: 0.3.2
     Port: 9001
     Tessera_Config_Dir: 7nodes
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 200Mi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -47,3 +36,14 @@ geth:
     public: false
   # general verbosity of geth [1..5]
   verbosity: 9
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: ClusterIP
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP.
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 200M

--- a/7nodes/raft-7nodes-constellation/qubernetes-raft-constellation-7nodes-pvc.yaml
+++ b/7nodes/raft-7nodes-constellation/qubernetes-raft-constellation-7nodes-pvc.yaml
@@ -1,5 +1,3 @@
-#namespace:
-#  name: quorum-test
 # number of nodes to deploy
 nodes:
   number: 7

--- a/7nodes/raft-7nodes-tessera/qubernetes-raft-tessera-7nodes-pvc.yaml
+++ b/7nodes/raft-7nodes-tessera/qubernetes-raft-tessera-7nodes-pvc.yaml
@@ -3,12 +3,7 @@
 # number of nodes to deploy
 nodes:
   number: 7
-service:
-  # NodePort | ClusterIP
-  type: ClusterIP
 quorum:
-  # supported: raft | istanbul
-  consensus: raft
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -18,7 +13,8 @@ quorum:
   Genesis_File: 7nodes/raft-genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: raft | istanbul
+    consensus: raft
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.5.0
   # related to transaction manager containers
@@ -26,16 +22,9 @@ quorum:
     # (tessera|constellation)
     # container images at https://hub.docker.com/u/quorumengineering/
     Name: tessera
-    Tm_Version: 0.11
+    Tm_Version: 0.10.4
     Port: 9001
     Tessera_Config_Dir: 7nodes
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 200Mi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -47,3 +36,14 @@ geth:
     public: false
   # general verbosity of geth [1..5]
   verbosity: 9
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: ClusterIP
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP.
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 200M

--- a/7nodes/raft-7nodes-tessera/qubernetes-raft-tessera-7nodes-pvc.yaml
+++ b/7nodes/raft-7nodes-tessera/qubernetes-raft-tessera-7nodes-pvc.yaml
@@ -1,5 +1,3 @@
-#namespace:
-#  name: quorum-test
 # number of nodes to deploy
 nodes:
   number: 7

--- a/examples/config/qubernetes-custom-docker-repo.yaml
+++ b/examples/config/qubernetes-custom-docker-repo.yaml
@@ -4,12 +4,7 @@
 sep_deployment_files: true
 nodes:
   number: 4
-service:
-  # NodePort | ClusterIP
-  type: NodePort
 quorum:
-  # supported: (raft | istanbul)
-  consensus: istanbul
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -19,7 +14,8 @@ quorum:
   Genesis_File: out/config/genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: (raft | istanbul)
+    consensus: istanbul
     Quorum_Version: 2.4.0
     # the docker repo that hold your quorum container
     Docker_Repo: %%YOUR_CUSTOM_DOCKER_REPO%%
@@ -33,14 +29,6 @@ quorum:
     Port: 9001
     3Party_Port: 9080
     Tessera_Config_Dir: out/config
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP
-  # The data dir is persisted here
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 5Gi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -54,3 +42,15 @@ geth:
   verbosity: 9
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\"
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: NodePort
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP
+  # The data dir is persisted here
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 5Gi

--- a/examples/config/qubernetes-custom-docker-repo.yaml
+++ b/examples/config/qubernetes-custom-docker-repo.yaml
@@ -1,5 +1,3 @@
-#namespace:
-#  name: quorum-test
 # number of nodes to deploy
 nodes:
   number: 4

--- a/examples/config/qubernetes-custom-docker-repo.yaml
+++ b/examples/config/qubernetes-custom-docker-repo.yaml
@@ -1,7 +1,6 @@
 #namespace:
 #  name: quorum-test
 # number of nodes to deploy
-sep_deployment_files: true
 nodes:
   number: 4
 quorum:
@@ -43,6 +42,7 @@ geth:
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\"
 k8s:
+  sep_deployment_files: true
   service:
     # NodePort | ClusterIP
     type: NodePort
@@ -53,4 +53,4 @@ k8s:
     # PVC (Persistent_Volume_Claim - tested with GCP).
     Type: PVC
     ## when redeploying cannot be less than previous values
-    Capacity: 5Gi
+    Capacity: 1Gi

--- a/examples/config/qubernetes-ingress-ws.yaml
+++ b/examples/config/qubernetes-ingress-ws.yaml
@@ -4,19 +4,11 @@
 sep_deployment_files: true
 nodes:
   number: 4
-service:
-  # NodePort | ClusterIP | LoadBalancer
-  type: NodePort
-  Ingress:
-    # OneToMany | OneToOne
-    Strategy: OneToMany
-    Host: "quorum.ws.testnet.com"
-    ws: true
 quorum:
-  # supported: (raft | istanbul)
-  consensus: istanbul
   # related to quorum containers
   quorum:
+    # supported: (raft | istanbul)
+    consensus: istanbul
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.2.5
   # related to transaction manager containers
@@ -25,6 +17,22 @@ quorum:
     # (tessera|constellation)
     Name: tessera
     Tm_Version: 0.11
+# generic geth related options
+geth:
+  Node_WSPort: 8546
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\" --wsaddr 0.0.0.0
+k8s:
+  service:
+    # NodePort | ClusterIP | LoadBalancer
+    type: NodePort
+    Ingress:
+      # OneToMany | OneToOne
+      Strategy: OneToMany
+      Host: "quorum.ws.testnet.com"
+      ws: true
   # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
   # test locally and on GCP
   # The data dir is persisted here
@@ -33,10 +41,3 @@ quorum:
     Type: PVC
     ## when redeploying cannot be less than previous values
     Capacity: 200Mi
-# generic geth related options
-geth:
-  Node_WSPort: 8546
-  # general verbosity of geth [1..5]
-  verbosity: 9
-  # additional startup params to pass into geth/quorum
-  Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\" --wsaddr 0.0.0.0

--- a/examples/config/qubernetes-ingress-ws.yaml
+++ b/examples/config/qubernetes-ingress-ws.yaml
@@ -1,7 +1,6 @@
 #namespace:
 # name: quorum-test
 # number of nodes to deploy
-sep_deployment_files: true
 nodes:
   number: 4
 quorum:
@@ -25,6 +24,7 @@ geth:
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\" --ws --wsorigins=\"*\" --wsaddr 0.0.0.0
 k8s:
+  sep_deployment_files: true
   service:
     # NodePort | ClusterIP | LoadBalancer
     type: NodePort

--- a/examples/config/qubernetes-ingress.yaml
+++ b/examples/config/qubernetes-ingress.yaml
@@ -1,7 +1,6 @@
 #namespace:
 # name: quorum-test
 # number of nodes to deploy
-sep_deployment_files: true
 nodes:
   number: 3
 quorum:
@@ -41,7 +40,9 @@ geth:
   verbosity: 9
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\"
+
 k8s:
+  sep_deployment_files: true
   service:
     # NodePort | ClusterIP | LoadBalancer
     type: NodePort

--- a/examples/config/qubernetes-ingress.yaml
+++ b/examples/config/qubernetes-ingress.yaml
@@ -4,16 +4,7 @@
 sep_deployment_files: true
 nodes:
   number: 3
-service:
-  # NodePort | ClusterIP | LoadBalancer
-  type: NodePort
-  Ingress:
-    # OneToMany | OneToOne
-    Strategy: OneToMany
-    Host: "quorum.testnet.com"
 quorum:
-  # supported: (raft | istanbul)
-  consensus: istanbul
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -23,7 +14,8 @@ quorum:
   Genesis_File: out/config/genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: (raft | istanbul)
+    consensus: istanbul
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.2.5
   # related to transaction manager containers
@@ -36,14 +28,6 @@ quorum:
     Port: 9001
     3Party_Port: 9080
     Tessera_Config_Dir: out/config
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP
-  # The data dir is persisted here
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 200Mi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -57,3 +41,19 @@ geth:
   verbosity: 9
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\"
+k8s:
+  service:
+    # NodePort | ClusterIP | LoadBalancer
+    type: NodePort
+    Ingress:
+      # OneToMany | OneToOne
+      Strategy: OneToOne
+      Host: "quorum.testnet.com"
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP
+  # The data dir is persisted here
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 200Mi

--- a/examples/config/qubernetes-ingress.yaml
+++ b/examples/config/qubernetes-ingress.yaml
@@ -1,5 +1,3 @@
-#namespace:
-# name: quorum-test
 # number of nodes to deploy
 nodes:
   number: 3

--- a/examples/config/qubernetes-istanbul-7nodes.yaml
+++ b/examples/config/qubernetes-istanbul-7nodes.yaml
@@ -5,12 +5,7 @@ namespace:
 # see: 7nodes directory for already generated quorum resources and various qubernetes.yaml files.
 nodes:
   number: 7 
-service:
-  # NodePort | ClusterIP
-  type: ClusterIP
 quorum:
-  # supported: (raft | istanbul)
-  consensus: istanbul 
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -20,13 +15,13 @@ quorum:
   Genesis_File: 7nodes/istanbul-7nodes/istanbul-genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: (raft | istanbul)
+    consensus: istanbul
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.2.3
   # related to transaction manager containers
   tm:
     # container images at https://hub.docker.com/u/quorumengineering/
-    #       in that case.
     Tm_Version: 0.3.2
     3Party_Port: 9080
     Port: 9001
@@ -41,3 +36,7 @@ geth:
     public: false
   # general verbosity of geth [1..5]
   verbosity: 9
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: ClusterIP

--- a/examples/config/qubernetes-istanbul-7nodes.yaml
+++ b/examples/config/qubernetes-istanbul-7nodes.yaml
@@ -1,5 +1,3 @@
-namespace:
-  name: quorum-test
 # number of nodes to deploy, this is relying on already generated files which reside in the 7nodes
 # directory, so teh number will always be 7.
 # see: 7nodes directory for already generated quorum resources and various qubernetes.yaml files.
@@ -37,6 +35,8 @@ geth:
   # general verbosity of geth [1..5]
   verbosity: 9
 k8s:
+  namespace:
+    name: quorum-test
   service:
     # NodePort | ClusterIP
     type: ClusterIP

--- a/examples/config/qubernetes-istanbul-generate-8nodes.yaml
+++ b/examples/config/qubernetes-istanbul-generate-8nodes.yaml
@@ -1,5 +1,3 @@
-namespace:
-  name: quorum-test
 # number of nodes to deploy
 nodes:
   number: 8
@@ -38,6 +36,8 @@ geth:
   # general verbosity of geth [1..5]
   verbosity: 9
 k8s:
+  namespace:
+    name: quorum-test
   service:
     # NodePort | ClusterIP
     type: ClusterIP

--- a/examples/config/qubernetes-istanbul-generate-8nodes.yaml
+++ b/examples/config/qubernetes-istanbul-generate-8nodes.yaml
@@ -3,12 +3,7 @@ namespace:
 # number of nodes to deploy
 nodes:
   number: 8
-service:
-  # NodePort | ClusterIP
-  type: ClusterIP
 quorum:
-  # supported: (raft | istanbul)
-  consensus: istanbul
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -18,7 +13,8 @@ quorum:
   Genesis_File: out/config/genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: (raft | istanbul)
+    consensus: istanbul
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.2.3
   # related to transaction manager containers
@@ -30,13 +26,6 @@ quorum:
     Port: 9001
     3Party_Port: 9080
     Tessera_Config_Dir: out/config
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 200Mi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -48,3 +37,14 @@ geth:
     public: false
   # general verbosity of geth [1..5]
   verbosity: 9
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: ClusterIP
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  # test locally and on GCP
+  storage:
+    # PVC (Persistent_Volume_Claim - tested with GCP).
+    Type: PVC
+    ## when redeploying cannot be less than previous values
+    Capacity: 200Mi

--- a/examples/config/qubernetes-network-policy.yaml
+++ b/examples/config/qubernetes-network-policy.yaml
@@ -1,7 +1,6 @@
 #namespace:
 #  name: quorum-test
 # number of nodes to deploy
-sep_deployment_files: true
 nodes:
   number: 4
 service:
@@ -57,3 +56,6 @@ geth:
   verbosity: 9
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\"
+
+k8s:
+  sep_deployment_files: true

--- a/examples/config/qubernetes-pvc-annotations.yaml
+++ b/examples/config/qubernetes-pvc-annotations.yaml
@@ -4,12 +4,7 @@
 sep_deployment_files: true
 nodes:
   number: 4
-service:
-  # NodePort | ClusterIP
-  type: NodePort
 quorum:
-  # supported: (raft | istanbul)
-  consensus: istanbul
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -18,8 +13,9 @@ quorum:
   Permissioned_Nodes_File: out/config/permissioned-nodes.json
   Genesis_File: out/config/genesis.json
   # related to quorum containers
-  quorum:
-    Raft_Port: 50401
+  quoruom:
+    # supported: (raft | istanbul)
+    consensus: istanbul
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.4.0
   # related to transaction manager containers
@@ -31,13 +27,6 @@ quorum:
     Port: 9001
     3Party_Port: 9080
     Tessera_Config_Dir: out/config
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  storage:
-    PVC:
-      annotations:
-        volume.beta.kubernetes.io/storage-class: "YOUR_STORAGE_CLASS"
-      ## when redeploying cannot be less than previous values
-      Capacity: 5Gi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -51,3 +40,15 @@ geth:
   verbosity: 9
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\"
+
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: NodePort
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  storage:
+    PVC:
+      annotations:
+        volume.beta.kubernetes.io/storage-class: "YOUR_STORAGE_CLASS"
+      ## when redeploying cannot be less than previous values
+      Capacity: 1Gi

--- a/examples/config/qubernetes-pvc-annotations.yaml
+++ b/examples/config/qubernetes-pvc-annotations.yaml
@@ -1,7 +1,6 @@
 #namespace:
 #  name: quorum-test
 # number of nodes to deploy
-sep_deployment_files: true
 nodes:
   number: 4
 quorum:
@@ -42,6 +41,7 @@ geth:
   Geth_Startup_Params: --rpccorsdomain=\"*\"
 
 k8s:
+  sep_deployment_files: true
   service:
     # NodePort | ClusterIP
     type: NodePort

--- a/examples/config/qubernetes-pvc-storageclass.yaml
+++ b/examples/config/qubernetes-pvc-storageclass.yaml
@@ -4,12 +4,7 @@
 sep_deployment_files: true
 nodes:
   number: 4
-service:
-  # NodePort | ClusterIP
-  type: NodePort
 quorum:
-  # supported: (raft | istanbul)
-  consensus: istanbul
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -19,7 +14,8 @@ quorum:
   Genesis_File: out/config/genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: (raft | istanbul)
+    consensus: istanbul
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.4.0
   # related to transaction manager containers
@@ -31,13 +27,7 @@ quorum:
     Port: 9001
     3Party_Port: 9080
     Tessera_Config_Dir: out/config
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  storage:
-    PVC:
-      # optional storage class, if you don't know what this is,
-      storageClassName: my-csi-plugin
-      ## when redeploying cannot be less than previous values
-      Capacity: 5Gi
+
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -51,3 +41,14 @@ geth:
   verbosity: 9
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\"
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: NodePort
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  storage:
+    PVC:
+      # optional storage class, if you don't know what this is,
+      storageClassName: my-csi-plugin
+      ## when redeploying cannot be less than previous values
+      Capacity: 1Gi

--- a/examples/config/qubernetes-pvc-storageclass.yaml
+++ b/examples/config/qubernetes-pvc-storageclass.yaml
@@ -1,7 +1,6 @@
 #namespace:
 #  name: quorum-test
 # number of nodes to deploy
-sep_deployment_files: true
 nodes:
   number: 4
 quorum:
@@ -42,6 +41,7 @@ geth:
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\"
 k8s:
+  sep_deployment_files: true
   service:
     # NodePort | ClusterIP
     type: NodePort

--- a/examples/config/qubernetes-raft-generate-8nodes.yaml
+++ b/examples/config/qubernetes-raft-generate-8nodes.yaml
@@ -3,12 +3,7 @@ namespace:
 # number of nodes to deploy
 nodes:
   number: 8
-service:
-  # NodePort | ClusterIP
-  type: ClusterIP
 quorum:
-  # supported: (raft | istanbul)
-  consensus: raft 
   # base quorum data dir as set inside each container.
   Node_DataDir: /etc/quorum/qdata
   # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
@@ -18,7 +13,8 @@ quorum:
   Genesis_File: out/config/genesis.json
   # related to quorum containers
   quorum:
-    Raft_Port: 50401
+    # supported: (raft | istanbul)
+    consensus: raft
     # container images at https://hub.docker.com/u/quorumengineering/
     Quorum_Version: 2.2.3
   # related to transaction manager containers
@@ -41,3 +37,7 @@ geth:
     public: false
   # general verbosity of geth [1..5]
   verbosity: 9
+k8s:
+  service:
+    # NodePort | ClusterIP
+    type: ClusterIP

--- a/examples/config/qubernetes-security-context.yaml
+++ b/examples/config/qubernetes-security-context.yaml
@@ -1,7 +1,6 @@
 #namespace:
 # name: quorum-test
 # number of nodes to deploy
-sep_deployment_files: true
 nodes:
   number: 3
 quorum:
@@ -42,6 +41,7 @@ geth:
   # additional startup params to pass into geth/quorum
   Geth_Startup_Params: --rpccorsdomain=\"*\" --rpcvhosts=\"*\"
 k8s:
+  sep_deployment_files: true
   # optionally  allow a security context to be set for the deployment, e.g. can the user have root access?
   securityContext:
     runAsUser: 430

--- a/examples/config/qubernetes-security-context.yaml
+++ b/examples/config/qubernetes-security-context.yaml
@@ -1,5 +1,3 @@
-#namespace:
-# name: quorum-test
 # number of nodes to deploy
 nodes:
   number: 3

--- a/examples/config/qubernetes-security-context.yaml
+++ b/examples/config/qubernetes-security-context.yaml
@@ -4,13 +4,6 @@
 sep_deployment_files: true
 nodes:
   number: 3
-service:
-  # NodePort | ClusterIP | LoadBalancer
-  type: NodePort
-  Ingress:
-    # OneToMany | OneToOne
-    Strategy: OneToOne
-    Host: "quorum.testnet.com"
 quorum:
   # supported: (raft | istanbul)
   consensus: istanbul
@@ -35,14 +28,6 @@ quorum:
     Port: 9001
     3Party_Port: 9080
     Tessera_Config_Dir: out/config
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP
-  # The data dir is persisted here
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 200Mi
 # generic geth related options
 geth:
   Node_RPCPort: 8545
@@ -62,3 +47,18 @@ k8s:
     runAsUser: 430
     fsGroup: 430
     supplementalGroups: [666,777]
+  service:
+    # NodePort | ClusterIP | LoadBalancer
+    type: NodePort
+    Ingress:
+      # OneToMany | OneToOne
+      Strategy: OneToOne
+      Host: "quorum.testnet.com"
+    # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+    # test locally and on GCP
+    # The data dir is persisted here
+    storage:
+      # PVC (Persistent_Volume_Claim - tested with GCP).
+      Type: PVC
+      ## when redeploying cannot be less than previous values
+      Capacity: 200Mi

--- a/examples/config/qubes-minimal.yaml
+++ b/examples/config/qubes-minimal.yaml
@@ -15,4 +15,4 @@ quorum:
   tm:
     # (tessera|constellation)
     Name: tessera
-    Tm_Version: 0.11
+    Tm_Version: 0.10.4

--- a/qube-init
+++ b/qube-init
@@ -41,8 +41,8 @@ puts "using config file: " + @CONFIG_FILE
 
 # Generate deployments in a single file, or in separate files.
 @sep_deployment_files=false
-if @config["sep_deployment_files"] != nil
-  @sep_deployment_files = @config["sep_deployment_files"]
+if @config["k8s"] and @config["k8s"]["sep_deployment_files"] != nil
+  @sep_deployment_files = @config["k8s"]["sep_deployment_files"]
 end
 
 

--- a/qubernetes
+++ b/qubernetes
@@ -90,10 +90,8 @@ end
 
 # If the namespace is set in the config, create it and add it to all the resources.
 @Namespace = ""
-if @config["namespace"] != nil
-  if @config["namespace"]["name"] != ""
-@Namespace = "namespace: " + @config["namespace"]["name"]
-   end
+if @config["k8s"] and @config["k8s"]["namespace"] != nil and @config["k8s"]["namespace"]["name"] != ""
+@Namespace = "namespace: " + @config["k8s"]["namespace"]["name"]
 end
 
 # What kind of persistent storage is desired?

--- a/qubernetes
+++ b/qubernetes
@@ -159,7 +159,7 @@ File.open("out/03.0-quorum-services.yaml", "w") do |f|
 end
 
 # Create the Ingress resources if they are configured
-if @config["service"] and @config["service"]["Ingress"]
+if @config["k8s"] and @config["k8s"]["service"] and @config["k8s"]["service"]["Ingress"]
   File.open("out/03.1-quorum-ingress.yaml", "w") do |f|
     f.puts (ERB.new(File.read(@base_template_path + "/quorum-ingress.yaml.erb"), nil, "-").result)
   end

--- a/qubernetes
+++ b/qubernetes
@@ -84,8 +84,8 @@ end
 
 # Generate deployments in a single file, or in separate files.
 @sep_deployment_files=false
-if @config["sep_deployment_files"] != nil
-  @sep_deployment_files = @config["sep_deployment_files"]
+if @config["k8s"] and @config["k8s"]["sep_deployment_files"] != nil
+  @sep_deployment_files = @config["k8s"]["sep_deployment_files"]
 end
 
 # If the namespace is set in the config, create it and add it to all the resources.

--- a/qubernetes.yaml
+++ b/qubernetes.yaml
@@ -1,55 +1,18 @@
-#namespace:
-#  name: quorum-test
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+
 # number of nodes to deploy
-sep_deployment_files: true
 nodes:
-  number: 7
-service:
-  # NodePort | ClusterIP
-  type: NodePort
+  number: 4
 quorum:
-  # supported: (raft | istanbul)
-  consensus: istanbul
-  # base quorum data dir as set inside each container.
-  Node_DataDir: /etc/quorum/qdata
-  # This is where all the keys are store, and/or where they are generated, as in the case of quorum-keygen.
-  # Either full or relative paths on the machine generating the config
-  Key_Dir_Base: out/config
-  Permissioned_Nodes_File: out/config/permissioned-nodes.json
-  Genesis_File: out/config/genesis.json
-  # related to quorum containers
   quorum:
-    Raft_Port: 50401
-    # container images at https://hub.docker.com/u/quorumengineering/
+    # supported: (raft | istanbul)
+    consensus: istanbul
     Quorum_Version: 2.2.5
-  # related to transaction manager containers
   tm:
-    # container images at https://hub.docker.com/u/quorumengineering/
     # (tessera|constellation)
     Name: tessera
-    #Tm_Version: 0.9.2
-    Tm_Version: 0.10.2
-    Port: 9001
-    3Party_Port: 9080
-    Tessera_Config_Dir: out/config
-  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
-  # test locally and on GCP
-  # The data dir is persisted here
-  storage:
-    # PVC (Persistent_Volume_Claim - tested with GCP).
-    Type: PVC
-    ## when redeploying cannot be less than previous values
-    Capacity: 200Mi
-# generic geth related options
-geth:
-  Node_RPCPort: 8545
-  NodeP2P_ListenAddr: 30303
-  network:
-    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
-    id: 1101
-    # public (true|false) is it a public network?
-    public: false
-  # general verbosity of geth [1..5]
-  verbosity: 9
-  # additional startup params to pass into geth/quorum
-  Geth_Startup_Params: --rpccorsdomain=\"*\"
+    Tm_Version: 0.10.4

--- a/templates/k8s/persistent-volumes.yaml.erb
+++ b/templates/k8s/persistent-volumes.yaml.erb
@@ -36,9 +36,9 @@ end
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: <%= @config["namespace"]["name"] %>
+  name: <%= @config["k8s"]["namespace"]["name"] %>
   labels:
-    name: <%= @config["namespace"]["name"] %>
+    name: <%= @config["k8s"]["namespace"]["name"] %>
 <%- end %>
 ---
 

--- a/templates/k8s/persistent-volumes.yaml.erb
+++ b/templates/k8s/persistent-volumes.yaml.erb
@@ -11,12 +11,12 @@ end
 ##       be removed in the future and only `storage: PVC: [Annotations: Capacity]` will be supported.
 
 # if the user set storage params, override the defaults, and add their config.
-if @config["quorum"]["storage"]
-  if @config["quorum"]["storage"]["PVC"]
-    @Storage_Config = @config["quorum"]["storage"]["PVC"]
+if @config["k8s"] and @config["k8s"]["storage"]
+  if @config["k8s"]["storage"]["PVC"]
+    @Storage_Config = @config["k8s"]["storage"]["PVC"]
     @Capacity =  @Storage_Config["Capacity"]
   else
-    @Storage_Config = @config["quorum"]["storage"]
+    @Storage_Config = @config["k8s"]["storage"]
     @Capacity =  @Storage_Config["Capacity"]
   end
 

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -239,10 +239,10 @@ spec:
            touch $QUORUM_DATA_DIR/password.txt;
            NETWORK_ID=<%= @Geth_Network_Id %>
            RPC_APIS=admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum
-         <%- if @config["quorum"]["consensus"] == "raft" -%>
+         <%- if @config["quorum"]["quorum"]["consensus"] == "raft" -%>
            args=\" --gcmode archive --raft  --raftport <%= @Raft_Port %> \";
            RPC_APIS=\"$RPC_APIS,raft\";
-         <%- elsif @config["quorum"]["consensus"] == "istanbul" -%>
+         <%- elsif @config["quorum"]["quorum"]["consensus"] == "istanbul" -%>
            args=\" --gcmode archive --istanbul.blockperiod 3 --syncmode full --mine --minerthreads 1 \";
            RPC_APIS=\"$RPC_APIS,istanbul\";
          <%- end -%>
@@ -311,7 +311,7 @@ spec:
           mountPath: <%= @Node_DataDir%>/permission-nodes
         - name: geth-helpers
           mountPath: /geth-helpers
-        <%- if @config["quorum"]["consensus"] == "istanbul" -%>
+        <%- if @config["quorum"]["quorum"]["consensus"] == "istanbul" -%>
         - name: istanbul-validator-config
           mountPath: <%= @Node_DataDir%>/istanbul-validator-config.toml
         - name: node-management
@@ -388,7 +388,7 @@ spec:
             - key: geth-exec.sh
               path: geth-exec.sh
           defaultMode: 0777
-      <% if @config["quorum"]["consensus"] == "istanbul" %>
+      <% if @config["quorum"]["quorum"]["consensus"] == "istanbul" %>
       - name: istanbul-validator-config
         configMap:
           name: istanbul-validator-config.toml

--- a/templates/k8s/quorum-genesis-config.yaml.erb
+++ b/templates/k8s/quorum-genesis-config.yaml.erb
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: <%= @config["namespace"]["name"] %>
+  name: <%= @config["k8s"]["namespace"]["name"] %>
   labels:
-    name: <%= @config["namespace"]["name"] %>
+    name: <%= @config["k8s"]["namespace"]["name"] %>
     <%- end %>
 ---
 

--- a/templates/k8s/quorum-ingress.yaml.erb
+++ b/templates/k8s/quorum-ingress.yaml.erb
@@ -6,14 +6,14 @@ end
 
 
 @Geth_WS = false
-if @config["service"]["Ingress"] then
+if @config["k8s"] and @config["k8s"]["service"]["Ingress"] then
    @Ingress = true
    # OneForAll
-   @IngressStrategy = @config["service"]["Ingress"]["Strategy"]
-   if @config["service"]["Ingress"]["Host"]  then
-     @Ingress_Host = @config["service"]["Ingress"]["Host"]
+   @IngressStrategy = @config["k8s"]["service"]["Ingress"]["Strategy"]
+   if @config["k8s"]["service"]["Ingress"]["Host"]  then
+     @Ingress_Host = @config["k8s"]["service"]["Ingress"]["Host"]
    end
-   if @config["service"]["Ingress"]["ws"]  then
+   if @config["k8s"]["service"]["Ingress"]["ws"]  then
      @Geth_WS = true
    end
 end

--- a/templates/k8s/quorum-services.yaml.erb
+++ b/templates/k8s/quorum-services.yaml.erb
@@ -8,8 +8,8 @@ end
 # NodePort | ClusterIP | Loadbalancer
 # default to NodePort if not set
 @Service_Type = "NodePort"
-if @config["service"] and  @config["service"]["type"]
- @Service_Type = @config["service"]["type"]
+if @config["k8s"] and @config["k8s"]["service"] and  @config["k8s"]["service"]["type"]
+ @Service_Type = @config["k8s"]["service"]["type"]
 end
 -%>
 

--- a/templates/k8s/quorum-shared-config.yaml.erb
+++ b/templates/k8s/quorum-shared-config.yaml.erb
@@ -85,7 +85,7 @@ data:
 <% end -%>
 
 
-<% if @config["quorum"]["consensus"] == "istanbul" %>
+<% if @config["quorum"]["quorum"]["consensus"] == "istanbul" %>
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/templates/k8s/quorum-shared-config.yaml.erb
+++ b/templates/k8s/quorum-shared-config.yaml.erb
@@ -128,7 +128,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: geth-helpers
-    <%= @Namespace %>
+  <%= @Namespace %>
   labels:
     app: qubernetes
     name: geth-helpers

--- a/templates/quorum/genesis.json.erb
+++ b/templates/quorum/genesis.json.erb
@@ -15,7 +15,7 @@ end
 
 -%>
 
-<% if @config["quorum"]["consensus"] == "raft" %>
+<% if @config["quorum"]["quorum"]["consensus"] == "raft" %>
 {
 "alloc": {
 <%- @nodes.each_with_index do |node, indexNode|
@@ -76,7 +76,7 @@ end
   "parenthash": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "timestamp": "0x00"
 }
-<% elsif @config["quorum"]["consensus"] == "istanbul" %>
+<% elsif @config["quorum"]["quorum"]["consensus"] == "istanbul" %>
 {
 "alloc": {
 <%- @nodes.each_with_index do |node, indexNode|


### PR DESCRIPTION
* `quorum` config (key/values) are now separate from the k8s keys/values in the config, ingress, services, namespace, etc. live under their own yaml key `k8s:`
* update 7node configs to reflect changes.
* update example configs to reflect changes.