### PR TITLE
Add support for prometheus geth monitoring.

### DIFF
--- a/examples/config/qubernetes-monitor.yaml
+++ b/examples/config/qubernetes-monitor.yaml
@@ -1,0 +1,28 @@
+# This is the simplest configuration file, only specifying:
+#   1. the number of nodes
+#   2. quorum's consensus (istanbul IBFT, or Raft)
+#   3. the version of the quorum container and the transaction manger container.
+# Reasonable defaults will be chosen for the rest of the values, ports, associated K8s resources, etc.
+
+# number of nodes to deploy
+nodes:
+  number: 4
+quorum:
+  quorum:
+    # supported: (raft | istanbul)
+    consensus: istanbul
+    Quorum_Version: 2.6.0
+  tm:
+    # (tessera|constellation)
+    Name: tessera
+    Tm_Version: 0.10.4
+geth:
+  #Geth_Startup_Params: --rpccorsdomain=\"*\" --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
+  Geth_Startup_Params: --rpccorsdomain=\"*\"
+
+# monitor will enable prometheus geth monitoring, grafana is kept external for now.
+prometheus:
+  # override the default monitor startup params --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0.
+  #monitor_params_geth: --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0
+  nodePort_prom: 31323
+

--- a/qubernetes
+++ b/qubernetes
@@ -202,7 +202,18 @@ else
   end
 end
 
+if @config["prometheus"]
+  `rm -f out/config/prometheus.yml`
+  File.open("out/config/prometheus.yml", "a") do |f|
+    f.puts (ERB.new(File.read("templates/monitor/prometheus.yml.erb"), nil, "-").result)
+  end
 
+  `rm -f out/06-quorum-monitor.yaml`
+  File.open("out/06-quorum-monitor.yaml", "a") do |f|
+    f.puts (ERB.new(File.read(@base_template_path + "/monitor.yaml.erb"), nil, "-").result)
+    f.puts("---")
+  end
+end
 
 puts("\n")
 puts "  Success! ".green

--- a/templates/k8s/monitor.yaml.erb
+++ b/templates/k8s/monitor.yaml.erb
@@ -1,0 +1,93 @@
+<%-
+def set_node_template_vars(values)
+    @Node_UserIdent = values["Node_UserIdent"]
+    @Service_Prefix = (@Node_UserIdent.upcase).gsub("-", "_")
+    return
+end
+-%>
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  <%= @Namespace %>
+  name: monitor-deployment
+spec:
+  selector:
+    matchLabels:
+      name: quorum-monitor
+  template:
+    metadata:
+      name:  quorum-monitor
+      labels:
+        app: qubernetes
+        tier: backend
+        name: quorum-monitor
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v2.19.1
+        command: [ "sh" ]
+        args:
+          - "-cx"
+          - "
+             mkdir -p /prometheus/myprometheus;
+             cp  /etc/prometheus/prometheus.yml /prometheus/myprometheus/prometheus.yaml;
+            <%- @nodes.each do |node| -%>
+             <%= set_node_template_vars(node.values.first) -%>
+sed -i \"s/<%= @Service_Prefix %>_SERVICE_HOST/$<%= @Service_Prefix %>_SERVICE_HOST/g\" /prometheus/myprometheus/prometheus.yaml;
+            <%- end -%>
+             /bin/prometheus --config.file=/prometheus/myprometheus/prometheus.yaml --storage.tsdb.path=/prometheus/;"
+        ports:
+          - containerPort: 9090
+        volumeMounts:
+          - name: prometheus-config-volume
+            mountPath: /etc/prometheus
+          - name: prometheus-storage-volume
+            mountPath: /prometheus/
+      volumes:
+          - name: prometheus-config-volume
+            configMap:
+              name: prometheus-server-conf
+          - name: prometheus-storage-volume
+            emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  <%= @Namespace %>
+  name: quorum-monitor
+  labels:
+    app: qubernetes
+    tier: backend
+    name: quorum-monitor
+spec:
+  selector:
+    app: qubernetes
+    tier: backend
+    name: quorum-monitor
+  # NodePort | ClusterIP | Loadbalancer
+  type: NodePort
+  ports:
+    - name: prometheus
+      protocol: TCP
+      targetPort: 9090
+      port: 9090
+ <%- if @config["prometheus"] and @config["prometheus"]["nodePort_prom"]  -%>
+      nodePort: <%= @config["prometheus"]["nodePort_prom"] %>
+ <%- end -%>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-server-conf
+    <%= @Namespace %>
+  labels:
+    app: qubernetes
+    name: prometheus-server-conf
+data:
+  prometheus.yml: |-
+<%- File.readlines("out/config/prometheus.yml").each do |line| -%>
+     <%= line -%>
+<%- end -%>

--- a/templates/k8s/quorum-deployment.yaml.erb
+++ b/templates/k8s/quorum-deployment.yaml.erb
@@ -43,6 +43,7 @@ end
    @Security_Context = @config["k8s"]["securityContext"]
  end
 %>
+<%- @This_Host = ("#{@Node_UserIdent}".upcase + "_SERVICE_HOST").gsub("-", "_") -%>
 # The quorum deployment consists of
 # 1. the transaction manager / private tx container (constellation or tessera)
 # 2. the quorum node container
@@ -148,7 +149,7 @@ spec:
 
            CONFIG_TMPL=$(cat ${DDIR}/tessera-config${TESSERA_CONFIG_TYPE}.json.tmpl);
 
-           <%- @This_Host = ("#{@Node_UserIdent}".upcase + "_SERVICE_HOST").gsub("-", "_") -%>
+
            echo  \"<%= @Sed_Set_Node_Service_Host %>\";
            CONFIG_WITH_OTHER_HOSTS=$(echo $CONFIG_TMPL | <%= @Sed_Set_Node_Service_Host %>) ;
            CONFIG_WITH_ALL_HOSTS=$(echo $CONFIG_WITH_OTHER_HOSTS | sed \"s/%THIS_SERVICE_HOST%/$<%= @This_Host %>/g\");
@@ -266,6 +267,13 @@ spec:
            --wsapi $RPC_APIS \
            --wsport <%= @Node_WSPort %> \
            --port <%= @NodeP2P_ListenAddr %> \
+      <%- if @config["prometheus"] -%>
+         <%- if @config["prometheus"]["monitor_params_geth"]-%>
+            <%= @config["prometheus"]["monitor_params_geth"]%> \
+         <%- else -%>
+           --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0 \
+         <%- end -%>
+      <%- end -%>
            <%= @Geth_Startup_Params %> \
            --password $QUORUM_DATA_DIR/password.txt 2>&1 | tee -a <%= @Node_DataDir%>/logs/quorum.log;"
         ports:
@@ -273,6 +281,9 @@ spec:
           - containerPort: <%= @Node_RPCPort %>
           - containerPort: <%= @Node_WSPort %>
           - containerPort: <%= @NodeP2P_ListenAddr %>
+        <% if @config["prometheus"] %>
+          - containerPort: 6060
+        <% end %>
         env:
         - name: PRIVATE_CONFIG
           value: <%= @Node_DataDir %>/tm/tm.ipc
@@ -321,10 +332,6 @@ spec:
           mountPath: <%= @Node_DataDir%>/node-management/ibft_propose_all.sh
           subPath: ibft_propose_all.sh
         <%- end -%>
-          #subPath: permissioned-nodes.json
-       # - name: quorum-permissioned-config
-       #   mountPath: <%= @Node_DataDir%>/dd/static-nodes.json.tmpl
-       #   subPath: permissioned-nodes.json
       volumes:
       - name: quorum-permissioned-config
         configMap:

--- a/templates/k8s/quorum-services.yaml.erb
+++ b/templates/k8s/quorum-services.yaml.erb
@@ -59,5 +59,10 @@ spec:
       protocol: TCP
       targetPort: <%= @Raft_Port %>
       port: <%= @Raft_Port %>
-
+<% if @config["prometheus"]  %>
+    - name: prometheus
+      protocol: TCP
+      targetPort: 6060
+      port: 6060
+<% end %>
 <%- end %> <%# end node iteration %>

--- a/templates/k8s/quorum-shared-config.yaml.erb
+++ b/templates/k8s/quorum-shared-config.yaml.erb
@@ -142,3 +142,5 @@ data:
 <%- File.readlines("helpers/container/geth-exec.sh").each do |line| -%>
     <%= line -%>
 <% end -%>
+
+

--- a/templates/monitor/prometheus.yml.erb
+++ b/templates/monitor/prometheus.yml.erb
@@ -1,0 +1,29 @@
+<%-
+
+def set_node_template_vars(values)
+    @Node_UserIdent = values["Node_UserIdent"]
+    @Service_Prefix = (@Node_UserIdent.upcase).gsub("-", "_")
+    return
+end
+-%>
+
+global:
+  scrape_interval: 5s
+  scrape_timeout: 5s
+  evaluation_interval: 5s
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: []
+      scheme: http
+      timeout: 5s
+scrape_configs:
+  - job_name: geth
+    metrics_path: /debug/metrics/prometheus
+    scheme: http
+    static_configs:
+      - targets:
+  <%- @nodes.each do |node| -%>
+  <%= set_node_template_vars(node.values.first) -%>
+        - <%= @Service_Prefix %>_SERVICE_HOST:6060
+  <%- end -%>


### PR DESCRIPTION
* optionally allow enabling prometheus monitoring of geth.
* if monitoring is enabled, start geth with the metric / monitoring params and create k8s deployment for prometheus server that 
  connect to geth monitoring/metrics endpoints.
* allow for a configureable nodeport for the prometheus server deployment service.