### PR TITLE
Add support for custom k8s storageClass.

### DIFF
--- a/examples/config/qube-storageclass.yaml
+++ b/examples/config/qube-storageclass.yaml
@@ -1,0 +1,42 @@
+#namespace:
+#  name: quorum-test
+# number of nodes to deploy
+nodes:
+  number: 4
+quorum:
+  # related to quorum containers
+  quorum:
+    # supported: (raft | istanbul)
+    consensus: istanbul
+    Quorum_Version: 2.4.0
+  tm:
+    # container images at https://hub.docker.com/u/quorumengineering/
+    Name: tessera
+    Tm_Version: 0.10.2
+# generic geth related options
+geth:
+  network:
+    id: 1101
+    public: false
+  # general verbosity of geth [1..5]
+  verbosity: 9
+  # additional startup params to pass into geth/quorum
+  Geth_Startup_Params: --rpccorsdomain=\"*\"
+
+k8s:
+  sep_deployment_files: true
+  service:
+    # NodePort | ClusterIP
+    type: NodePort
+  # persistent storage is handled by Persistent Volume Claims (PVC) https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+  storage:
+    PVC:
+      storageClass:
+        # should exist under templates/k8s/storage-classes and be `yaml.erb` files, e.g. templates/k8s/storage-classes/ks-storage-class.yaml.erb
+        template: eks-storage-class
+        name: io1
+        provisioner: kuberentes.io/aws-ebs
+        kmsKeyId: arn:aws:kms:us-east-1:...
+      storageClassName: io1
+      ## when redeploying cannot be less than previous values
+      Capacity: 1Gi

--- a/qubernetes
+++ b/qubernetes
@@ -140,11 +140,24 @@ end
 @base_template_path = "templates/k8s"
 #puts (sed_string)
 puts "PVC"
+
 if @Storage_Type == "PVC"
-  File.open("out/00-quorum-persistent-volumes.yaml", "w") do |f|
-    f.puts (ERB.new(File.read(@base_template_path + "/persistent-volumes.yaml.erb"), nil, "-").result)
+  # there is a custom storage class set, e.g. for EKS storage class.
+  if  @config.dig("k8s", "storage", "PVC", "storageClass","template")
+    @storage_class_template = @config["k8s"]["storage"]["PVC"]["storageClass"]["template"]
+    File.open("out/00-quorum-persistent-volumes.yaml", "w") do |f|
+      f.puts (ERB.new(File.read(@base_template_path + "/storage-classes/" + @storage_class_template + ".yaml.erb"), nil, "-").result)
+    end
+    File.open("out/00-quorum-persistent-volumes.yaml", "a") do |f|
+      f.puts (ERB.new(File.read(@base_template_path + "/persistent-volumes.yaml.erb"), nil, "-").result)
+    end
+  else
+    File.open("out/00-quorum-persistent-volumes.yaml", "w") do |f|
+      f.puts (ERB.new(File.read(@base_template_path + "/persistent-volumes.yaml.erb"), nil, "-").result)
+    end
   end
 end
+
 File.open("out/01-quorum-genesis.yaml", "w") do |f|
   f.puts (ERB.new(File.read(@base_template_path + "/quorum-genesis-config.yaml.erb"), nil, "-").result)
 end

--- a/templates/k8s/persistent-volumes.yaml.erb
+++ b/templates/k8s/persistent-volumes.yaml.erb
@@ -39,8 +39,9 @@ metadata:
   name: <%= @config["k8s"]["namespace"]["name"] %>
   labels:
     name: <%= @config["k8s"]["namespace"]["name"] %>
-<%- end %>
+
 ---
+<%- end %>
 
 <%- @nodes.each do |node| -%>
     <%= set_node_template_vars(node.values.first) -%>

--- a/templates/k8s/storage-classes/eks-storage-class.yaml.erb
+++ b/templates/k8s/storage-classes/eks-storage-class.yaml.erb
@@ -1,0 +1,26 @@
+<%
+if @config["k8s"]["storage"]["PVC"]["storageClass"]
+  @Name = @config["k8s"]["storage"]["PVC"]["storageClass"]["name"]
+  @KmsKeyId = @config["k8s"]["storage"]["PVC"]["storageClass"]["kmsKeyId"]
+end
+@ReclaimPolicy = "Delete"
+if @config["k8s"]["storage"]["PVC"]["storageClass"]["reclaimPolicy"]
+  @ReclaimPolicy = @config["k8s"]["storage"]["PVC"]["storageClass"]["reclaimPolicy"]
+end
+%>
+
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: <%= @Name %>
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kuberentes.io/aws-ebs
+reclaimPolicy: <%=  @ReclaimPolicy %>
+parameters:
+  type:  <%= @Name %>
+  iopsPerGB: "10"
+  fsType: ext4
+  encrypted: "true"
+  kmsKeyId: <%= @KmsKeyId %>

--- a/templates/k8s/storage-classes/eks-storage-class.yaml.erb
+++ b/templates/k8s/storage-classes/eks-storage-class.yaml.erb
@@ -16,7 +16,7 @@ metadata:
   name: <%= @Name %>
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-provisioner: kuberentes.io/aws-ebs
+provisioner: kubernetes.io/aws-ebs
 reclaimPolicy: <%=  @ReclaimPolicy %>
 parameters:
   type:  <%= @Name %>


### PR DESCRIPTION
This is necessary for some k8s runtimes, e.g. EKS. See examples/config/qube-storageclass.yaml.

Templates for custom storageClasses should be placed under `templates/k8s/storage-classes`.